### PR TITLE
Make travis build pdfs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+before_install:
+- curl -L https://github.com/holgern/travis-texlive/releases/download/2017-07-05_09/texlive.tar.xz | tar -JxC ~
+- sudo apt-get update
+
+install:
+- PATH=$HOME/texlive/bin/x86_64-linux:$PATH
+- sudo apt-get install python-pygments
+- sudo apt-get install ghostscript
+
+script:
+- cd specification
+- ./compile.sh

--- a/specification/compile.sh
+++ b/specification/compile.sh
@@ -7,12 +7,20 @@ mkdir out &> /dev/null
 cp -fP *.bib out/ &> /dev/null
 
 rm out/$SRC.pdf
+rm out/$SRC.log
 
-pdflatex --halt-on-error --shell-escape -output-directory=out ../$SRC.tex
+pdflatex --halt-on-error --shell-escape $SRC.tex
 #cd out
 #bibtex $SRC
 #cd ..
-pdflatex --halt-on-error --shell-escape -output-directory=out ../$SRC.tex
-pdflatex --halt-on-error --shell-escape -output-directory=out ../$SRC.tex
+pdflatex --halt-on-error --shell-escape $SRC.tex
+pdflatex --halt-on-error --shell-escape $SRC.tex
 
-rm *.pdf*
+mv $SRC.pdf out/$SRC.pdf
+mv $SRC.log out/$SRC.log
+
+rm $SRC.aux
+rm $SRC.lof
+rm $SRC.lot
+rm $SRC.out
+rm $SRC.toc


### PR DESCRIPTION
This PR makes travis build the pdf with texlive.

If it is desired we should be able to set up a dedicated github account for "uavcan-specification-buildbot" that will post the .pdf into the respective PR using the following resource:

 - https://damien.pobel.fr/post/github-api-from-travisci/
 - https://stackoverflow.com/questions/37786539/how-to-upload-github-asset-file-using-curl
