### PR TITLE
Note on the use of the transfer ID value for purposes of temporal synchronization of message streams

### DIFF
--- a/specification/physical_layer/physical_layer.tex
+++ b/specification/physical_layer/physical_layer.tex
@@ -18,7 +18,7 @@ directly correspond to those defined in the chapter \ref{sec:transport_layer}.
 This section contains certain generic hardware design recommendations that are agnostic of a particular
 physical layer implementation.
 
-\subsection{Non-uniform transport redundancy}
+\subsection{Non-uniform transport redundancy}\label{sec:phy_non_uniform_transport_redundancy}
 
 Mission critical devices and non-mission critical devices often need to co-exist within the same UAVCAN network.
 Non-mission critical devices are likely to be equipped with a non-redundant transport interface,

--- a/specification/transport_layer/transport_layer.tex
+++ b/specification/transport_layer/transport_layer.tex
@@ -386,7 +386,11 @@ It is recognized that perfectly simultaneous transmission may not be possible du
 utilization rates of the redundant interfaces and different phasing of their traffic;
 however, that is not an issue for UAVCAN.
 If perfectly simultaneous frame submission is not possible, interfaces with lower numerical index
-should be handled in the first order.
+should be handled in the first order\footnote{It should be kept in mind that redundant interfaces
+are used for increased fault tolerance, not for load sharing reasons.
+Whenever a node is connected to an interface, the likelihood of its failure is increased;
+therefore, backup interfaces should interconnect only mission-critical equipment.
+See section \ref{sec:phy_non_uniform_transport_redundancy}.}.
 
 An exception to the above rule applies if the payload of the transfer depends on some properties
 of the interface through which the transfer is emitted.
@@ -540,6 +544,16 @@ require any background maintenance processes.
     to the application requirements (e.g., maximum recovery time in the event of an interface failure),
     or the protocol stack can estimate this value automatically by analyzing the transfer intervals. \\
 \end{UAVCANSimpleTable}
+
+It might be useful to clarify why immediate switching between interfaces is not allowed,
+and why nodes are required to let the first interface time out before using the next one.
+The transfer ID value wraps around every 32 transfers.
+Different interfaces are expected to exhibit different latencies even in a properly functioning system,
+especially if the system contains both redundantly-interfaced and non-redundantly-interfaced nodes.
+If the latency of a backup interface relative to the primary interface exceeds 32 transfer intervals,
+and receiving nodes were to be allowed to switch between interfaces freely disregarding the timeout,
+the receiving node would skip the whole period of transfer ID (32 transfers will be lost).
+The problem would primarily affect low-priority transfers where large latencies are possible.
 
 \subsection{State update in a redundant interface configuration}
 

--- a/specification/transport_layer/transport_layer.tex
+++ b/specification/transport_layer/transport_layer.tex
@@ -178,9 +178,8 @@ that is provided for every transfer.
 This value is crucial for many aspects of UAVCAN communication\footnote{One might be tempted to use the transfer ID
 value for temporal synchronization of parallel message streams originating from the same node,
 where messages bearing the same transfer ID value are supposed to correspond to the same moment of time.
-Such use case is explicitly discouraged due to the fact that the overflow interval of the transfer ID value
-is insufficiently long, which creates the risk of undetected phase slip of one of the message streams by
-more than 32 messages behind.
+Such use is strongly discouraged because it is impossible to detect if one node is more than
+32 messages behind another.
 If temporal synchronization is necessary, explicit time stamping should be used instead.};
 specifically:
 \begin{description}
@@ -386,16 +385,17 @@ It is recognized that perfectly simultaneous transmission may not be possible du
 utilization rates of the redundant interfaces and different phasing of their traffic;
 however, that is not an issue for UAVCAN.
 If perfectly simultaneous frame submission is not possible, interfaces with lower numerical index
-should be handled in the first order\footnote{It should be kept in mind that redundant interfaces
-are used for increased fault tolerance, not for load sharing reasons.
-Whenever a node is connected to an interface, the likelihood of its failure is increased;
-therefore, backup interfaces should interconnect only mission-critical equipment.
-See section \ref{sec:phy_non_uniform_transport_redundancy}.}.
+should be handled in the first order.
 
 An exception to the above rule applies if the payload of the transfer depends on some properties
 of the interface through which the transfer is emitted.
 An example of such a special case is the time synchronization algorithm leveraged by UAVCAN
 (documented in the chapter \ref{sec:application_layer} of the specification).
+
+Redundant interfaces are used for increased fault tolerance, not for load sharing reasons.
+Whenever a node is connected to an interface the likelihood of the interface failing is increased.
+This suggests that backup interfaces may only interconnect with mission-critical equipment.
+See section \ref{sec:phy_non_uniform_transport_redundancy}.
 
 \section{Transfer reception}\label{sec:transfer_reception}
 
@@ -545,9 +545,8 @@ require any background maintenance processes.
     or the protocol stack can estimate this value automatically by analyzing the transfer intervals. \\
 \end{UAVCANSimpleTable}
 
-It might be useful to clarify why immediate switching between interfaces is not allowed,
-and why nodes are required to let the first interface time out before using the next one.
-The transfer ID value wraps around every 32 transfers.
+The reason nodes are required to let the first interface time out before using the next one
+is that the transfer ID field is expected to wrap around frequently (every 32 transfers).
 Different interfaces are expected to exhibit different latencies even in a properly functioning system,
 especially if the system contains both redundantly-interfaced and non-redundantly-interfaced nodes.
 If the latency of a backup interface relative to the primary interface exceeds 32 transfer intervals,

--- a/specification/transport_layer/transport_layer.tex
+++ b/specification/transport_layer/transport_layer.tex
@@ -175,7 +175,14 @@ delaying their transmission until there are no more higher priority transfers to
 
 The \emph{transfer ID} is a small unsigned integer value in the range from 0 to 31, inclusive,
 that is provided for every transfer.
-This value is crucial for many aspects of UAVCAN communication; specifically:
+This value is crucial for many aspects of UAVCAN communication\footnote{One might be tempted to use the transfer ID
+value for temporal synchronization of parallel message streams originating from the same node,
+where messages bearing the same transfer ID value are supposed to correspond to the same moment of time.
+Such use case is explicitly discouraged due to the fact that the overflow interval of the transfer ID value
+is insufficiently long, which creates the risk of undetected phase slip of one of the message streams by
+more than 32 messages behind.
+If temporal synchronization is necessary, explicit time stamping should be used instead.};
+specifically:
 \begin{description}
     \item[Message sequence monitoring] - the continuously increasing transfer ID allows receiving nodes to
     detect lost messages and detect when a message stream from any remote node is interrupted.

--- a/specification/transport_layer/transport_layer.tex
+++ b/specification/transport_layer/transport_layer.tex
@@ -545,13 +545,13 @@ require any background maintenance processes.
     or the protocol stack can estimate this value automatically by analyzing the transfer intervals. \\
 \end{UAVCANSimpleTable}
 
-The reason nodes are required to let the first interface time out before using the next one
-is that the transfer ID field is expected to wrap around frequently (every 32 transfers).
+Nodes are required to let the first interface time out before using the next one because the
+transfer ID field is expected to wrap around frequently (every 32 transfers).
 Different interfaces are expected to exhibit different latencies even in a properly functioning system,
 especially if the system contains both redundantly-interfaced and non-redundantly-interfaced nodes.
 If the latency of a backup interface relative to the primary interface exceeds 32 transfer intervals,
 and receiving nodes were to be allowed to switch between interfaces freely disregarding the timeout,
-the receiving node would skip the whole period of transfer ID (32 transfers will be lost).
+the receiving node would skip the whole period of transfer IDs (32 transfers will be lost).
 The problem would primarily affect low-priority transfers where large latencies are possible.
 
 \subsection{State update in a redundant interface configuration}


### PR DESCRIPTION
Added a minor footnote on the page 28 section 4.2.1. [UAVCAN_Specification.pdf](https://github.com/UAVCAN/specification/files/2408965/UAVCAN_Specification.pdf)
