### PR TITLE
Proofreading of Chapter 3 - DSDL specification

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ before_script:
   - apt-get install -y python3 python3-pip
   - apt-get install -y git
   - apt-get install -y ghostscript
-  - pip3 install pydsdl
+  - pip3 install -r requirements.txt
 
 job:
   image: ubuntu:16.04

--- a/render_dsdl.py
+++ b/render_dsdl.py
@@ -53,7 +53,7 @@ def get_dsdl_submodule_commit_hash() -> str:
                                    cwd=ROOT_NAMESPACE_SUPERDIRECTORY).decode('ascii').strip()
 
 
-def render_dsdl_length_table(t: pydsdl.CompoundType) -> str:
+def render_dsdl_length_table(t: pydsdl.CompositeType) -> str:
     def bit_to_byte(val: tuple) -> tuple:
         return tuple((x + 7) // 8 for x in val)
 
@@ -95,7 +95,7 @@ def render_dsdl_length_table(t: pydsdl.CompoundType) -> str:
     ])
 
 
-def render_dsdl_definition(t: pydsdl.CompoundType) -> str:
+def render_dsdl_definition(t: pydsdl.CompositeType) -> str:
     minted_params = r'fontsize=\scriptsize, numberblanklines=true, baselinestretch=0.9, autogobble=false'
     return '\n'.join([
         r'\begin{minted}[%s]{python}' % minted_params,
@@ -286,7 +286,7 @@ for namespace, children in grouped.items():
         is_service = isinstance(versions[0], pydsdl.ServiceType)
 
         print(r'\pagebreak[3]{}')
-        print(r'\subsection{%s}' % full_name.split(pydsdl.CompoundType.NAME_COMPONENT_SEPARATOR)[-1])
+        print(r'\subsection{%s}' % full_name.split(pydsdl.CompositeType.NAME_COMPONENT_SEPARATOR)[-1])
         print(r'\label{sec:dsdl:%s}' % full_name)
         print(r'Full %s type name: {\bfseries\texttt{%s}}' %
               ('service' if is_service else 'message', escape(full_name)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# This file lists the Python dependencies that are necessary to build the specification.
+pygments
+pydsdl~=0.5

--- a/specification/application_layer/conventions.tex
+++ b/specification/application_layer/conventions.tex
@@ -4,14 +4,14 @@
 
 An overview of related concepts is provided in chapter \ref{sec:basic_concepts}.
 
-\subsubsection{Node ID}
+\subsubsection{Node-ID}
 
-Valid values of node ID range from 0 to 127, inclusive.
+Valid values of node-ID range from 0 up to a transport-specific upper boundary which is guaranteed to be above 127.
 
-The node ID values 126 and 127 are reserved for diagnostic and debugging tools;
-these node ID values should not be used in fielded systems.
+Two uppermost node-ID values are reserved for diagnostic and debugging tools;
+these node-ID values should not be used in fielded systems.
 
-\subsubsection{Port ID}
+\subsubsection{Port-ID}
 
 This rule is mandatory for all applications.
 
@@ -28,7 +28,7 @@ The ranges are summarized in the table \ref{table:application_port_id_distributi
 Unused gaps are reserved for future expansion of adjacent ranges.
 
 \begin{UAVCANSimpleTable}{Port identifier distribution}{|l l X|}\label{table:application_port_id_distribution}
-    Subject ID          & Service ID        & Purpose \\
+    Subject-ID          & Service-ID        & Purpose \\
     $[0, 24575]$        & $[0, 127]$        & Unregulated identifiers (both fixed and non-fixed). \\
     $[28672, 29695]$    & $[256, 319]$      & Non-standard regulated identifiers (i.e., vendor-specific). \\
     $[31744, 32767]$    & $[384, 511]$      & Standard regulated identifiers. \\

--- a/specification/basic_concepts/basic_concepts.tex
+++ b/specification/basic_concepts/basic_concepts.tex
@@ -234,7 +234,7 @@ Information contained in a published message is summarized in the table \ref{tab
                       of this message type from a given node. Used for message sequence monitoring,
                       multi-frame transfer reassembly, and elimination of transport frame duplication errors
                       for single-frame transfers. Additionally, Transfer-ID is crucial for automatic
-                      management of redundant transport interfaces. The properties of this field are explained in
+                      management of redundant transport interfaces. Its properties are explained in
                       detail in the chapter \ref{sec:transport_layer}. \\
 \end{UAVCANSimpleTable}
 
@@ -283,7 +283,7 @@ table \ref{table:service_req_resp_info}.
                       of this service type from a given node. Used for request/response matching,
                       multi-frame transfer reassembly, and elimination of transport frame duplication errors
                       for single-frame transfers. Additionally, Transfer-ID is crucial for automatic
-                      management of redundant transport interfaces. The properties of this field are explained in
+                      management of redundant transport interfaces. Its properties are explained in
                       detail in the chapter \ref{sec:transport_layer}. \\
 \end{UAVCANSimpleTable}
 

--- a/specification/basic_concepts/basic_concepts.tex
+++ b/specification/basic_concepts/basic_concepts.tex
@@ -9,7 +9,7 @@
 A UAVCAN network is a decentralized peer network, where each peer (node) has a unique
 numeric identifier\footnote{Here and elsewhere in this specification, \emph{ID} and \emph{identifier} are used
 interchangeably unless specifically indicated otherwise.}
---- \emph{node ID} --- ranging from 0 to 127, inclusively.
+--- \emph{node-ID} --- ranging from 0 up to a transport-specific upper boundary which is guaranteed to be above 127.
 Nodes of a UAVCAN network can communicate using the following communication methods:
 
 \begin{description}
@@ -39,9 +39,9 @@ Requests and their corresponding responses that belong to the same service use s
 the major version (minor versions are allowed to differ; as a consequence, the minor data type version number
 of a service response may differ from that of its corresponding request) and pertain to the same function.
 
-Each message subject is identified by a unique natural number -- a \emph{subject ID};
-likewise, each service is identified by a unique \emph{service ID}.
-An umbrella term \emph{port ID} is used to refer either to a subject ID or to a service ID
+Each message subject is identified by a unique natural number -- a \emph{subject-ID};
+likewise, each service is identified by a unique \emph{service-ID}.
+An umbrella term \emph{port-ID} is used to refer either to a subject-ID or to a service-ID
 (port identifiers have no direct manifestation in the construction of the protocol,
 but they are convenient for discussion).
 
@@ -49,16 +49,16 @@ but they are convenient for discussion).
 
 \subsubsection{Data type definitions}
 
-Message and service data types\footnote{Data types are the core concept of UAVCAN.}
+Message and service data types
 are defined using the \emph{data structure description language} (DSDL) (chapter \ref{sec:dsdl}).
-A DSDL definition specifies the name, major version, minor version, the data schema,
-and an optional predefined port ID of the data type.
+A DSDL definition specifies the name, major version, minor version, the data schemas,
+and an optional predefined port-ID of the data type among other less important properties.
 Message data types always define exactly one data schema, whereas
 service data types contain two independent schema definitions: one for request, and the other for response.
 
 If a port identifier is specified in a data type definition, such identifier is said to be a
 \emph{fixed port identifier}
-(by inheritance, the same naming principle applies to \emph{fixed subject ID} and \emph{fixed service ID}).
+(by inheritance, the same naming principle applies to \emph{fixed subject-ID} and \emph{fixed service-ID}).
 A data type can be used with an arbitrary number of different port identifiers assigned on a per-application basis,
 but not more than one fixed port identifier.
 
@@ -87,7 +87,7 @@ All standard data type definitions are regulated.
 
 Fixed port identifiers can be used only with regulated data type definitions or with private definitions.
 Fixed port identifiers must not be used with public unregulated data types,
-since that is likely to cause unresolvable port identifier collisions\footnote{
+since that is likely to cause unresolvable port identifier collisions\footnote{%
     Any system that relies on data type definitions with fixed port identifiers provided by
     an external party (i.e., data types and the system in question are designed by different parties)
     runs the risk of encountering port identifier conflicts that cannot be resolved without resorting to help
@@ -97,7 +97,7 @@ since that is likely to cause unresolvable port identifier collisions\footnote{
     or to the public at large it is important that the data type \emph{not} include a fixed port-identifier.
 }.
 This restriction shall be followed at all times by all compliant implementations and
-systems\footnote{
+systems\footnote{%
     In general, private unregulated fixed port identifiers are collision-prone by their nature, so they should
     be avoided unless there are very strong reasons for their usage and the authors fully understand the risks.
 }.
@@ -107,7 +107,7 @@ systems\footnote{
     \bfseries{Public}
     &
     Standard and contributed (e.g., vendor-specific) definitions.\newline
-    Fixed port identifiers are allowed; they are called \emph{``regulated port ID''}.
+    Fixed port identifiers are allowed; they are called \emph{``regulated port-ID''}.
     &
     Definitions distributed separately from the UAVCAN specification.\newline
     Fixed port identifiers are \emph{not allowed}.
@@ -118,19 +118,32 @@ systems\footnote{
     Nonexistent category.
     &
     Definitions that are not available to anyone except their authors.\newline
-    Fixed port identifiers are permitted (although not recommended) as long as the definition is only used by
-    its authors; they are called \emph{``unregulated fixed port ID''}.
+    Fixed port identifiers are permitted (although not recommended);
+    they are called \emph{``unregulated fixed port-ID''}.
     \\
 \end{UAVCANSimpleTable}
 
 DSDL processing tools shall prohibit unregulated fixed port identifiers by default,
 unless they are explicitly configured otherwise.
 
-Each of the two sets of valid port identifiers (which are subject identifiers and port identifiers) are
-segregated into three categories: application-specific (i.e., non-fixed or unregulated) identifiers,
-regulated non-standard port identifiers, and standard port identifiers.
-Fixed unregulated port identifiers can be allocated in the same range where application-specific identifiers are.
-The ranges are documented in chapter \ref{sec:application_layer}.
+Each of the two sets of valid port identifiers (which are subject identifiers and service identifiers) are
+segregated into three categories (the ranges are documented in chapter \ref{sec:application_layer}):
+
+\begin{itemize}
+    \item Application-specific port identifiers.
+    These can be assigned at runtime (in which case they are called non-fixed or runtime-assigned)
+    or at the data type definition time (in which case they are called \emph{fixed unregulated},
+    and they generally should be avoided due to the risks of collisions as explained earlier).
+
+    \item Regulated non-standard fixed port identifiers.
+    These are assigned by the specification maintainers for non-standard contributed
+    vendor-specific public data types.
+    They are always fixed and can't be assigned at runtime.
+
+    \item Standard fixed port identifiers. These are assigned by the specification maintainers
+    for standard regulated public data types.
+    They are always fixed and can't be assigned at runtime.
+\end{itemize}
 
 Data type authors that want to release regulated data type definitions or contribute to the standard data
 type set should contact the UAVCAN maintainers for coordination.
@@ -205,20 +218,20 @@ Information contained in a published message is summarized in the table \ref{tab
 \begin{UAVCANSimpleTable}{Published message properties}{|l X|}\label{table:published_message_info}
     Property        & Description \\
     Payload         & The serialized message object. \\
-    Subject ID      & Numerical identifier that indicates how the information should be interpreted. \\
-    Source node ID  & The node ID of the transmitting node (excepting anonymous messages). \\
-    Transfer ID     & A small overflowing integer that increments with every transfer
+    Subject-ID      & Numerical identifier that indicates how the information should be interpreted. \\
+    Source node-ID  & The node-ID of the transmitting node (excepting anonymous messages). \\
+    Transfer-ID     & A small overflowing integer that increments with every transfer
                       of this message type from a given node. Used for message sequence monitoring,
                       multi-frame transfer reassembly, and elimination of transport frame duplication errors
-                      for single-frame transfers. Additionally, Transfer ID is crucial for automatic
+                      for single-frame transfers. Additionally, Transfer-ID is crucial for automatic
                       management of redundant transport interfaces. The properties of this field are explained in
                       detail in the chapter \ref{sec:transport_layer}. \\
 \end{UAVCANSimpleTable}
 
 \subsection{Anonymous message publication}
 
-Nodes that don't have a unique node ID can publish only \emph{anonymous messages}.
-An anonymous message is different from a regular message in that it doesn't contain a source node ID,
+Nodes that don't have a unique node-ID can publish only \emph{anonymous messages}.
+An anonymous message is different from a regular message in that it doesn't contain a source node-ID,
 and that it can't be decomposed across several transport frames.
 
 UAVCAN nodes will not have an identifier initially until they are assigned one,
@@ -253,13 +266,13 @@ table \ref{table:service_req_resp_info}.
 \begin{UAVCANSimpleTable}{Service request/response properties}{|l X|}\label{table:service_req_resp_info}
     Property        & Description \\
     Payload         & The serialized request/response object. \\
-    Service ID      & Numerical identifier that indicates how the service should be handled. \\
-    Client node ID  & Source node ID during request transfer, destination node ID during response transfer. \\
-    Server node ID  & Destination node ID during request transfer, source node ID during response transfer. \\
-    Transfer ID     & A small overflowing integer that increments with every call
+    Service-ID      & Numerical identifier that indicates how the service should be handled. \\
+    Client node-ID  & Source node-ID during request transfer, destination node-ID during response transfer. \\
+    Server node-ID  & Destination node-ID during request transfer, source node-ID during response transfer. \\
+    Transfer-ID     & A small overflowing integer that increments with every call
                       of this service type from a given node. Used for request/response matching,
                       multi-frame transfer reassembly, and elimination of transport frame duplication errors
-                      for single-frame transfers. Additionally, Transfer ID is crucial for automatic
+                      for single-frame transfers. Additionally, Transfer-ID is crucial for automatic
                       management of redundant transport interfaces. The properties of this field are explained in
                       detail in the chapter \ref{sec:transport_layer}. \\
 \end{UAVCANSimpleTable}
@@ -267,4 +280,4 @@ table \ref{table:service_req_resp_info}.
 Both the request and the response contain same values for all listed fields except payload,
 where the content is application-defined.
 Clients match responses with corresponding requests using the following fields:
-service ID, client node ID, server node ID, and transfer ID.
+service-ID, client node-ID, server node-ID, and transfer-ID.

--- a/specification/basic_concepts/basic_concepts.tex
+++ b/specification/basic_concepts/basic_concepts.tex
@@ -44,6 +44,7 @@ likewise, each service is identified by a unique \emph{service-ID}.
 An umbrella term \emph{port-ID} is used to refer either to a subject-ID or to a service-ID
 (port identifiers have no direct manifestation in the construction of the protocol,
 but they are convenient for discussion).
+The sets of subject-ID and service-ID are orthogonal.
 
 Port identifiers are assigned to various functions, processes, or data streams within the network
 at the system definition time.
@@ -65,7 +66,7 @@ but not more than one fixed port identifier.
 Message and service data types
 are defined using the \emph{data structure description language} (DSDL) (chapter \ref{sec:dsdl}).
 A DSDL definition specifies the name, major version, minor version, the data schemas,
-and an optional predefined port-ID of the data type among other less important properties.
+and an optional fixed port-ID of the data type among other less important properties.
 Message data types always define exactly one data schema, whereas
 service data types contain two independent schema definitions: one for request, and the other for response.
 

--- a/specification/basic_concepts/basic_concepts.tex
+++ b/specification/basic_concepts/basic_concepts.tex
@@ -45,6 +45,19 @@ An umbrella term \emph{port-ID} is used to refer either to a subject-ID or to a 
 (port identifiers have no direct manifestation in the construction of the protocol,
 but they are convenient for discussion).
 
+Port identifiers are assigned to various functions, processes, or data streams within the network
+at the system definition time.
+Generally, a port identifier can be selected arbitrarily by a system integrator
+by changing relevant configuration parameters of connected nodes,
+in which case such port identifiers are called \emph{non-fixed port identifiers}.
+It is also possible to permanently associate any data type definition with a particular port identifier
+at a data type definition time,
+in which case such port identifiers are called \emph{fixed port identifiers};
+their usage is governed by rules and regulations described in later sections.
+
+A data type can be used with an arbitrary number of non-fixed different port identifiers,
+but not more than one fixed port identifier.
+
 \subsection{Data types}
 
 \subsubsection{Data type definitions}
@@ -55,12 +68,6 @@ A DSDL definition specifies the name, major version, minor version, the data sch
 and an optional predefined port-ID of the data type among other less important properties.
 Message data types always define exactly one data schema, whereas
 service data types contain two independent schema definitions: one for request, and the other for response.
-
-If a port identifier is specified in a data type definition, such identifier is said to be a
-\emph{fixed port identifier}
-(by inheritance, the same naming principle applies to \emph{fixed subject-ID} and \emph{fixed service-ID}).
-A data type can be used with an arbitrary number of different port identifiers assigned on a per-application basis,
-but not more than one fixed port identifier.
 
 \subsubsection{Regulation}\label{sec:basic_concepts_data_type_regulation}
 
@@ -131,7 +138,8 @@ segregated into three categories (the ranges are documented in chapter \ref{sec:
 
 \begin{itemize}
     \item Application-specific port identifiers.
-    These can be assigned at runtime (in which case they are called non-fixed or runtime-assigned)
+    These can be assigned by changing relevant configuration parameters of the connected nodes
+    (in which case they are called \emph{non-fixed} or runtime-assigned),
     or at the data type definition time (in which case they are called \emph{fixed unregulated},
     and they generally should be avoided due to the risks of collisions as explained earlier).
 

--- a/specification/basic_concepts/basic_concepts.tex
+++ b/specification/basic_concepts/basic_concepts.tex
@@ -147,11 +147,9 @@ segregated into three categories (the ranges are documented in chapter \ref{sec:
     \item Regulated non-standard fixed port identifiers.
     These are assigned by the specification maintainers for non-standard contributed
     vendor-specific public data types.
-    They are always fixed and can't be assigned at runtime.
 
     \item Standard fixed port identifiers. These are assigned by the specification maintainers
     for standard regulated public data types.
-    They are always fixed and can't be assigned at runtime.
 \end{itemize}
 
 Data type authors that want to release regulated data type definitions or contribute to the standard data
@@ -174,14 +172,17 @@ Alternatively, a DSDL description can be used to construct appropriate serializa
 DSDL ensures that the worst case memory footprint and computational complexity per data type
 are constant and easily predictable.
 
-Serialized message and service objects are exchanged by means of the transport
+Serialized message and service objects\footnote{%
+    Here and elsewhere, an \emph{object} means a value that is an instance of a well-defined type.
+}
+are exchanged by means of the transport
 layer (chapter \ref{sec:transport_layer}), which implements automatic decomposition of
 long transfers into several transport frames\footnote{Here and
 elsewhere, a \emph{transport frame} means a block of data that can be atomically exchanged
 over the transport layer network, e.g., a CAN frame.} and reassembly from these transport frames
 back into a single atomic data block, allowing nodes to exchange serialized objects of
-arbitrary size (DSDL guarantees, however, that the size of the serialized representation
-of any object of any data type is always bounded and known statically).
+arbitrary size (DSDL guarantees, however, that the minimum and maximum size of the serialized representation
+of any object of any data type is always known statically).
 
 \subsection{High-level functions}
 

--- a/specification/basic_concepts/basic_concepts.tex
+++ b/specification/basic_concepts/basic_concepts.tex
@@ -9,7 +9,8 @@
 A UAVCAN network is a decentralized peer network, where each peer (node) has a unique
 numeric identifier\footnote{Here and elsewhere in this specification, \emph{ID} and \emph{identifier} are used
 interchangeably unless specifically indicated otherwise.}
---- \emph{node-ID} --- ranging from 0 up to a transport-specific upper boundary which is guaranteed to be above 127.
+--- \emph{node-ID} --- ranging from 0 up to a transport-specific upper boundary which is guaranteed to be
+not less than 127.
 Nodes of a UAVCAN network can communicate using the following communication methods:
 
 \begin{description}

--- a/specification/dsdl/architecture.tex
+++ b/specification/dsdl/architecture.tex
@@ -27,7 +27,8 @@ before the systems utilizing them are fielded.
 DSDL definitions can be used to automatically generate serialization (and deserialization) source code
 for any data type in a target programming language.
 A tool that is capable of generating serialization code based on a DSDL definition is called a \emph{DSDL compiler}.
-More generically, a software tool designed for working with DSDL definitions is called a \emph{DSDL processor}.
+More generically, a software tool designed for working with DSDL definitions is called a
+\emph{DSDL processing tool}.
 
 \subsection{Data types and namespaces}
 
@@ -113,12 +114,12 @@ provided that each version is defined at most once.
 Version number sequences can be non-contiguous,
 meaning that it is allowed to skip version numbers or remove existing definitions that are neither oldest nor newest.
 
-A data type definition may have an optional fixed port ID\footnote{Chapter \ref{sec:basic_concepts}.} value specified.
+A data type definition may have an optional fixed port-ID\footnote{Chapter \ref{sec:basic_concepts}.} value specified.
 
 The name of a data type definition file is constructed from the following entities
 joined via the ASCII dot character ``\verb|.|'' (ASCII code 46), in the specified order:
 \begin{itemize}
-    \item Fixed port ID in decimal notation, unless a fixed port ID is not provided for this definition.
+    \item Fixed port-ID in decimal notation, unless a fixed port-ID is not provided for this definition.
     \item Short name of the data type (mandatory, always non-empty).
     \item Major version number in decimal notation (mandatory).
     \item Minor version number in decimal notation (mandatory).
@@ -128,7 +129,7 @@ joined via the ASCII dot character ``\verb|.|'' (ASCII code 46), in the specifie
 \begin{figure}[H]
     $$
     \overbrace{%
-        \underbrace{\texttt{\huge{432}}}_{\substack{\text{fixed} \\ \text{port ID}}}%
+        \underbrace{\texttt{\huge{432}}}_{\substack{\text{fixed} \\ \text{port-ID}}}%
         \texttt{\huge{.}}%
     }^{\text{optional}}%
     \overbrace{%
@@ -164,28 +165,28 @@ An example DSDL directory structure is shown on the figure \ref{fig:dsdl_definit
         Nested namespace (also sub-root) \texttt{vendor\_x.foo}. \\\cline{2-2}
 
         \texttt{\qquad{}\qquad{}100.Run.1.0.uavcan} &
-        Data type definition v1.0 with fixed service ID 100. \\\cline{2-2}
+        Data type definition v1.0 with fixed service-ID 100. \\\cline{2-2}
 
         \texttt{\qquad{}\qquad{}100.Status.1.0.uavcan} &
-        Data type definition v1.0 with fixed subject ID 100. \\\cline{2-2}
+        Data type definition v1.0 with fixed subject-ID 100. \\\cline{2-2}
 
         \texttt{\qquad{}\qquad{}ID.1.0.uavcan} &
-        Data type definition v1.0 without fixed port ID. \\\cline{2-2}
+        Data type definition v1.0 without fixed port-ID. \\\cline{2-2}
 
         \texttt{\qquad{}\qquad{}ID.1.1.uavcan} &
-        Data type definition v1.1 without fixed port ID. \\\cline{2-2}
+        Data type definition v1.1 without fixed port-ID. \\\cline{2-2}
 
         \texttt{\qquad{}\qquad{}bar\_42/} &
         Nested namespace \texttt{vendor\_x.foo.bar\_42}. \\\cline{2-2}
 
         \texttt{\qquad{}\qquad{}\qquad{}101.List.1.0.uavcan} &
-        Data type definition v1.0 with fixed service ID 101. \\\cline{2-2}
+        Data type definition v1.0 with fixed service-ID 101. \\\cline{2-2}
 
         \texttt{\qquad{}\qquad{}\qquad{}102.List.2.0.uavcan} &
-        Data type definition v2.0 with fixed service ID 102. \\\cline{2-2}
+        Data type definition v2.0 with fixed service-ID 102. \\\cline{2-2}
 
         \texttt{\qquad{}\qquad{}\qquad{}ID.1.0.uavcan} &
-        Data type definition v1.0 without fixed port ID. \\\hline
+        Data type definition v1.0 without fixed port-ID. \\\hline
     \end{tabu}
     \caption{DSDL directory structure example.}\label{fig:dsdl_directory_structure_example}
 \end{figure}

--- a/specification/dsdl/architecture.tex
+++ b/specification/dsdl/architecture.tex
@@ -80,7 +80,7 @@ A set of full namespace names and a set of full data type names must not interse
     which are reviewed in a separate section.
 }.
 
-All names are case-sensitive.
+Data type names and namespace names are case-sensitive.
 However, names that differ only in letter case are not permitted\footnote{%
 Because that may cause problems with case-insensitive file systems.}.
 In other words, a pair of names which differ only in letter case is considered to constitute a name collision.
@@ -151,45 +151,45 @@ One directory cannot define more than one level of
 nesting\footnote{For example, ``\texttt{foo.bar}'' is not a valid directory name.
 The valid representation would be ``\texttt{bar}'' nested in ``\texttt{foo}''.}.
 
-An example DSDL directory structure is shown on the figure \ref{fig:dsdl_definition_file_name_structure}.
+\begin{remark}
+    \begin{figure}[H]
+        \begin{tabu}{|l|X|} \hline
+            \rowfont{\bfseries}
+            Directory tree & Entry description \\\hline
 
-\begin{figure}[H]
-    \begin{tabu}{|l|X|} \hline
-        \rowfont{\bfseries}
-        Directory tree & Entry description \\\hline
+            \texttt{vendor\_x/} &
+            Root namespace \texttt{vendor\_x}. \\\cline{2-2}
 
-        \texttt{vendor\_x/} &
-        Root namespace \texttt{vendor\_x}. \\\cline{2-2}
+            \texttt{\qquad{}foo/} &
+            Nested namespace (also sub-root) \texttt{vendor\_x.foo}. \\\cline{2-2}
 
-        \texttt{\qquad{}foo/} &
-        Nested namespace (also sub-root) \texttt{vendor\_x.foo}. \\\cline{2-2}
+            \texttt{\qquad{}\qquad{}100.Run.1.0.uavcan} &
+            Data type definition v1.0 with fixed service-ID 100. \\\cline{2-2}
 
-        \texttt{\qquad{}\qquad{}100.Run.1.0.uavcan} &
-        Data type definition v1.0 with fixed service-ID 100. \\\cline{2-2}
+            \texttt{\qquad{}\qquad{}100.Status.1.0.uavcan} &
+            Data type definition v1.0 with fixed subject-ID 100. \\\cline{2-2}
 
-        \texttt{\qquad{}\qquad{}100.Status.1.0.uavcan} &
-        Data type definition v1.0 with fixed subject-ID 100. \\\cline{2-2}
+            \texttt{\qquad{}\qquad{}ID.1.0.uavcan} &
+            Data type definition v1.0 without fixed port-ID. \\\cline{2-2}
 
-        \texttt{\qquad{}\qquad{}ID.1.0.uavcan} &
-        Data type definition v1.0 without fixed port-ID. \\\cline{2-2}
+            \texttt{\qquad{}\qquad{}ID.1.1.uavcan} &
+            Data type definition v1.1 without fixed port-ID. \\\cline{2-2}
 
-        \texttt{\qquad{}\qquad{}ID.1.1.uavcan} &
-        Data type definition v1.1 without fixed port-ID. \\\cline{2-2}
+            \texttt{\qquad{}\qquad{}bar\_42/} &
+            Nested namespace \texttt{vendor\_x.foo.bar\_42}. \\\cline{2-2}
 
-        \texttt{\qquad{}\qquad{}bar\_42/} &
-        Nested namespace \texttt{vendor\_x.foo.bar\_42}. \\\cline{2-2}
+            \texttt{\qquad{}\qquad{}\qquad{}101.List.1.0.uavcan} &
+            Data type definition v1.0 with fixed service-ID 101. \\\cline{2-2}
 
-        \texttt{\qquad{}\qquad{}\qquad{}101.List.1.0.uavcan} &
-        Data type definition v1.0 with fixed service-ID 101. \\\cline{2-2}
+            \texttt{\qquad{}\qquad{}\qquad{}102.List.2.0.uavcan} &
+            Data type definition v2.0 with fixed service-ID 102. \\\cline{2-2}
 
-        \texttt{\qquad{}\qquad{}\qquad{}102.List.2.0.uavcan} &
-        Data type definition v2.0 with fixed service-ID 102. \\\cline{2-2}
-
-        \texttt{\qquad{}\qquad{}\qquad{}ID.1.0.uavcan} &
-        Data type definition v1.0 without fixed port-ID. \\\hline
-    \end{tabu}
-    \caption{DSDL directory structure example.}\label{fig:dsdl_directory_structure_example}
-\end{figure}
+            \texttt{\qquad{}\qquad{}\qquad{}ID.1.0.uavcan} &
+            Data type definition v1.0 without fixed port-ID. \\\hline
+        \end{tabu}
+        \caption{DSDL directory structure example.}\label{fig:dsdl_directory_structure_example}
+    \end{figure}
+\end{remark}
 
 \subsection{Elements of data type definition}
 
@@ -198,25 +198,23 @@ A data type definition file contains an exhaustive description of a particular v
 As explained above, one data type definition contains either one or two data schema definitions,
 for message types and service types, respectively.
 
-The term \emph{attribute} is used to refer to either a field (including padding fields) or a constant
-associated with a particular object or type.
-
-A data schema definition contains an ordered, possibly empty collection of \emph{fields} and/or
-unordered, possibly empty collection of \emph{constants}.
+A data schema definition contains an ordered, possibly empty collection of \emph{field attributes} and/or
+unordered, possibly empty collection of \emph{constant attributes}.
 A data schema may describe either a \emph{structure object} or a \emph{tagged union object}.
-The value of a structure object is a function of the values of all of its fields.
-A tagged union object is formed from at least two fields,
-but it is capable of holding exactly one field at any given time.
-The value of a tagged union object is a function of which field it is holding at the moment and the value of said field.
+The value of a structure object is a function of the values of all of its field attributes.
+A tagged union object is formed from at least two field attributes,
+but it is capable of holding exactly one field attribute value at any given time.
+The value of a tagged union object is a function of which field attribute value
+it is holding at the moment and the value of said field attribute.
 
-A field represents a named dynamically assigned value of a statically defined type
+A field attribute represents a named dynamically assigned value of a statically defined type
 that can be exchanged over the network as a member of its containing object.
-A padding field is a special kind of field which is used for data alignment purposes;
-such fields are not named.
+A padding field attribute is a special kind of field attribute which is used for data alignment purposes;
+such field attributes are not named.
 
-A constant represents a named statically defined value of a statically defined type.
+A constant attribute represents a named statically defined value of a statically defined type.
 Constants are never exchanged over the network, since they are assumed to be known to all involved nodes
-by virtue of them sharing the same static definition of the data type.
+by virtue of them sharing compatible definitions of the data type.
 
 Constant values are defined via \emph{DSDL expressions},
 which are evaluated at the time of DSDL definition processing.
@@ -238,5 +236,5 @@ provided that the type of the object is known.
 \label{sec:dsdl_bit_length_set}
 A serialized representation is a sequence of binary digits (bits);
 the number of bits in a serialized representation is called its \emph{bit length}.
-A \emph{bit length set} of a data schema refers to the set of bit length values of all possible
-serialized representations of objects implementing the schema.
+A \emph{bit length set} of a data type (or a data schema) refers to the set of bit length values of all possible
+serialized representations of objects that are instances of the data type (or that follow the data schema).

--- a/specification/dsdl/architecture.tex
+++ b/specification/dsdl/architecture.tex
@@ -72,9 +72,17 @@ The name structure is illustrated on the figure \ref{fig:dsdl_data_type_name_str
     \caption{Data type name structure.\label{fig:dsdl_data_type_name_structure}}
 \end{figure}
 
-Data type names are case-sensitive.
-However, data type names that differ only in letter case are not permitted\footnote{%
+A set of full namespace names and a set of full data type names must not intersect\footnote{%
+    For example, a namespace ``\texttt{vendor.example}'' and a data type ``\texttt{vendor.example.1.0}''
+    are mutually exclusive.
+    Note the data type name shown in this example violates the naming conventions
+    which are reviewed in a separate section.
+}.
+
+All names are case-sensitive.
+However, names that differ only in letter case are not permitted\footnote{%
 Because that may cause problems with case-insensitive file systems.}.
+In other words, a pair of names which differ only in letter case is considered to constitute a name collision.
 
 A name component consists of alphanumeric ASCII characters (which are: \verb|A-Z|, \verb|a-z|, and \verb|0-9|)
 and underscore (``\verb|_|'', ASCII code 95).

--- a/specification/dsdl/attributes.tex
+++ b/specification/dsdl/attributes.tex
@@ -77,7 +77,7 @@ as specified in the table \ref{table:dsdl_constant_init_pattern}.
 Due to the value of a constant attribute being defined at the data type definition time,
 the cast mode of primitive-typed constants has no observable effect.
 
-\subsection{Local attributes}
+\subsection{Local attributes}\label{sec:dsdl_local_attributes}
 
 Local attributes are available at the DSDL definition processing time.
 

--- a/specification/dsdl/expression_types.tex
+++ b/specification/dsdl/expression_types.tex
@@ -144,8 +144,8 @@ The DSDL name of the set type is ``\verb|set|''.
 
 A set can be constructed from a set literal, in which case such set must contain at least one element.
 
-The attributes defined for set instances are listed in the table \ref{table:dsdl_set_attributes},
-where $E$ represents the set element type.
+The attributes and operators defined on set instances are listed in the tables~\ref{table:dsdl_set_attributes}
+and~\ref{table:dsdl_set_operators}, where $E$ represents the set element type.
 
 \begin{UAVCANSimpleTable}{Attributes defined on instances of sets}{|l l X X|}
     Name & Type & Constraints & Description
@@ -172,7 +172,8 @@ where $E$ represents the set element type.
     Elementwise $(E, E) \rightarrow R$.\\
 }
 
-\begin{UAVCANSimpleTable}{Operators defined on instances of sets}{|l l l X|}
+\begin{UAVCANSimpleTable}{Operators defined on instances of sets}{|l l l X|}%
+    \label{table:dsdl_set_operators}%
     Op & Type & Constraints & Description \\
 
     \texttt{\textbf{==}} & $(\texttt{set}_\texttt{<E>}, \texttt{set}_\texttt{<E>}) \rightarrow \texttt{bool}$ & &

--- a/specification/dsdl/expression_types.tex
+++ b/specification/dsdl/expression_types.tex
@@ -122,12 +122,12 @@ where the value of the constant is to be equal the code point of the symbol.
     Concatenation. \\
 
     \texttt{\textbf{!=}} & $(\texttt{string}, \texttt{string}) \rightarrow \texttt{bool}$ &
-    Inequality of Unicode NFC representations.
+    Inequality of Unicode NFC normalized forms.
     NFC stands for \emph{Normalization Form Canonical Composition} --
     one of standard Unicode normalization forms where characters are recomposed by canonical equivalence. \\
 
     \texttt{\textbf{==}} & $(\texttt{string}, \texttt{string}) \rightarrow \texttt{bool}$ &
-    Equality of normalized Unicode representations. \\
+    Equality of Unicode NFC normalized forms. \\
 
 \end{UAVCANSimpleTable}
 

--- a/specification/dsdl/expression_types.tex
+++ b/specification/dsdl/expression_types.tex
@@ -122,7 +122,9 @@ where the value of the constant is to be equal the code point of the symbol.
     Concatenation. \\
 
     \texttt{\textbf{!=}} & $(\texttt{string}, \texttt{string}) \rightarrow \texttt{bool}$ &
-    Inequality of normalized Unicode representations. \\
+    Inequality of Unicode NFC representations.
+    NFC stands for \emph{Normalization Form Canonical Composition} --
+    one of standard Unicode normalization forms where characters are recomposed by canonical equivalence. \\
 
     \texttt{\textbf{==}} & $(\texttt{string}, \texttt{string}) \rightarrow \texttt{bool}$ &
     Equality of normalized Unicode representations. \\

--- a/specification/dsdl/grammar.parsimonious
+++ b/specification/dsdl/grammar.parsimonious
@@ -65,7 +65,7 @@ type_primitive_name_floating_point   = "float" type_bit_length_suffix
 
 type_void = "void" type_bit_length_suffix
 
-type_bit_length_suffix = ~"[1-9]\d*"
+type_bit_length_suffix = ~r"[1-9]\d*"
 
 # ==================================================== Expressions ====================================================
 

--- a/specification/dsdl/serializable_types.tex
+++ b/specification/dsdl/serializable_types.tex
@@ -259,6 +259,23 @@ the referring definition is malformed\footnote{%
 This tainting behavior is designed to prevent unexpected breakage of
 type hierarchies when one of the deprecated dependencies reaches its end of life.}.
 
+When a data type is referred to from within an expression context,
+it constitutes a literal of type ``\verb|metaserializable|'' (section \ref{sec:dsdl_metaserializable}).
+If the referred data type is of the message kind,
+its attributes are accessible in the referring expression through application of the
+attribute reference operator ``\verb|.|''.
+The available attributes and their semantics are documented in the section \ref{sec:dsdl_local_attributes}.
+
+\begin{remark}
+    \begin{minted}{python}
+        uint64 MY_CONSTANT = vendor.MessageType.1.0.OTHER_CONSTANT
+        # The following is valid if the referring definition and the referred definition
+        # are located inside the root namespace "vendor":
+        uint64 MY_CONSTANT = MessageType.1.0.OTHER_CONSTANT
+        @print MessageType.1.0
+    \end{minted}
+\end{remark}
+
 \subsubsection{Unions}\label{sec:dsdl_composite_tagged_unions}
 
 Any data schema definition can be supplied with a special directive (section \ref{sec:dsdl_directives})
@@ -269,17 +286,3 @@ A tagged union must not contain padding field attributes.
 
 The value of a tagged union object is a function of the field attribute which value it is currently holding
 and the value of the field attribute itself.
-
-\subsubsection{Expressions}
-
-In the case of composite definitions of the message kind,
-attributes of the message type are accessible for use in DSDL expressions through application of the
-attribute reference operator ``\verb|.|'' to the corresponding instance of the serializable metatype.
-The available attributes and their semantics are documented in the section \ref{sec:dsdl_local_attributes}.
-
-\begin{remark}
-    \begin{minted}{python}
-        uint64 MY_CONSTANT = vendor.MessageType.1.0.OTHER_CONSTANT
-    \end{minted}
-\end{remark}
-

--- a/specification/dsdl/serializable_types.tex
+++ b/specification/dsdl/serializable_types.tex
@@ -26,8 +26,6 @@ Primitive types are assumed to be known to DSDL processing tools a priori,
 and as such, they need not be defined by the user.
 Primitive types can be referred to directly by their name from any namespace.
 
-The following text defines DSDL name patterns using the POSIX Extended Regular Expression (ERE) notation.
-
 \subsubsection{Hierarchy}
 
 The hierarchy of primitive types is documented below.
@@ -61,11 +59,11 @@ The hierarchy of primitive types is documented below.
     \end{itemize}
 \end{itemize}
 
-\begin{UAVCANSimpleTable}{Properties of integer types}{|l X l|}
+\begin{UAVCANSimpleTable}{Properties of integer types}{|l X l|}%
+    \label{table:dsd_integer_properties}%
     Category &
     DSDL names &
-    Range, $X$ is bit length
-    \label{table:dsd_integer_properties} \\
+    Range, $X$ is bit length \\
 
     Signed integers &
     \texttt{int2}, \texttt{int3}, \texttt{int4} \ldots{} \texttt{int62}, \texttt{int63}, \texttt{int64} &
@@ -172,7 +170,7 @@ The array element type can be any type except:
     In other words, indirect nesting of arrays is permitted.}.
 \end{itemize}
 
-The number of elements in the array can be specified as a constant at the data type definition time,
+The number of elements in the array can be specified as a constant expression at the data type definition time,
 in which case the array is said to be a \emph{fixed-length array}.
 Alternatively, the number of elements can vary between zero and some static limit specified
 at the data type definition time,
@@ -181,7 +179,7 @@ Variable-length arrays with unbounded maximum number of elements are not allowed
 
 Arrays are defined by adding a pair of square brackets after the array element type specification,
 where the brackets contain the \emph{array capacity expression}.
-The array capacity expression must yield a positive integer upon its evaluation;
+The array capacity expression must yield a positive integer of type ``\verb|rational|'' upon its evaluation;
 any other value or type renders the current DSDL definition invalid.
 
 The array capacity expression can be prefixed with the following character sequences in order to define
@@ -189,6 +187,7 @@ a variable-length array:
 \begin{itemize}
     \item ``\verb|<|'' (ASCII code 60) --- indicates that the integer value yielded by the array capacity expression
     specifies the non-inclusive upper boundary of the number of elements.
+    In this case, the integer value yielded by the array capacity expression must be greater than one.
 
     \item ``\verb|<=|'' (ASCII code 60 followed by 61) --- same as above, but the upper boundary is inclusive.
 \end{itemize}
@@ -274,8 +273,9 @@ and the value of the field attribute itself.
 \subsubsection{Expressions}
 
 In the case of composite definitions of the message kind,
-constant attributes of the message type are accessible through application of the
+attributes of the message type are accessible for use in DSDL expressions through application of the
 attribute reference operator ``\verb|.|'' to the corresponding instance of the serializable metatype.
+The available attributes and their semantics are documented in the section \ref{sec:dsdl_local_attributes}.
 
 \begin{remark}
     \begin{minted}{python}

--- a/specification/dsdl/serialization.tex
+++ b/specification/dsdl/serialization.tex
@@ -96,8 +96,7 @@ This behavior facilitates usage of void fields as placeholders for non-void fiel
 introduced in newer versions of the data type (section \ref{sec:dsdl_versioning}).
 
 \begin{remark}
-    The following data schema will be serialized as a sequence of three zero bits $000_2$
-    (five trailing padding bits not included):
+    The following data schema will be serialized as a sequence of three zero bits $000_2$:
     \begin{minted}{python}
         void3
     \end{minted}
@@ -117,7 +116,7 @@ introduced in newer versions of the data type (section \ref{sec:dsdl_versioning}
 Serialized representations of instances of the primitive type category that are longer than one byte (8 bits)
 are constructed as follows.
 First, only the least significant bytes that contain the used bits of the value are preserved;
-the rest are discarded following the transformation policy selected by the specified cast mode.
+the rest are discarded following the lossy assignment policy selected by the specified cast mode.
 Then the bytes are arranged in the least-significant-byte-first order\footnote{Also known as ``little endian''.}.
 If the bit width of the value is not an integer multiple of eight (8),
 the rightmost byte (i.e., the most significant byte) is shifted left until the most significant bit of the value

--- a/specification/dsdl/versioning.tex
+++ b/specification/dsdl/versioning.tex
@@ -248,7 +248,7 @@ where $t_{a.b}$ denotes a data type $t$ version $a.b$ ($a$ major, $b$ minor);
 $P(t)$ denotes the fixed port-ID (whose existence is optional) of data type $t$;
 $M$ is the set of message types, and $S$ is the set of service types.
 
-\subsubsection{Runtime port identifier assignment recommendations}
+\subsubsection{Non-fixed port identifier assignment recommendations}
 
 For port identifiers assigned at runtime
 it is recommended to ensure that any port identifier of a given kind (subject or service)

--- a/specification/dsdl/versioning.tex
+++ b/specification/dsdl/versioning.tex
@@ -250,7 +250,7 @@ $M$ is the set of message types, and $S$ is the set of service types.
 
 \subsubsection{Non-fixed port identifier assignment recommendations}
 
-For port identifiers assigned at runtime
+For non-fixed port identifiers assigned
 it is recommended to ensure that any port identifier of a given kind (subject or service)
 is only used with one major version of one data type.
 
@@ -272,7 +272,7 @@ When emitting a transfer, the major version of the data type is chosen at the di
 The minor version should be the newest available one under the chosen major version.
 
 When receiving a transfer, the node deduces which major version of the data type to use
-from its port identifier (either fixed or runtime-assigned).
+from its port identifier (either fixed or non-fixed).
 The minor version should be the newest available one under the deduced major version\footnote{%
 Such liberal minor version selection policy poses no compatibility risks since all definitions under the same
 major version are compatible with each other.}.

--- a/specification/dsdl/versioning.tex
+++ b/specification/dsdl/versioning.tex
@@ -191,7 +191,7 @@ the version numbers of its first definition must be assigned ``1.0'' (major 1, m
 
 In order to ensure predictability and functional safety of applications that leverage UAVCAN,
 the standard requires that once a data type definition is released,
-its DSDL source text, name, version numbers, fixed port ID, and other properties cannot undergo any
+its DSDL source text, name, version numbers, fixed port-ID, and other properties cannot undergo any
 modifications whatsoever, with the following exceptions:
 \begin{itemize}
     \item Whitespace changes of the DSDL source text are allowed,
@@ -230,7 +230,7 @@ all other versions must also be of the message kind.
 
 \subsubsection{Fixed port identifier assignment constraints}
 
-The following constraints apply to fixed port ID assignments:
+The following constraints apply to fixed port-ID assignments:
 \begin{align*}
     \exists P(x_{a.b})                          &\rightarrow \exists P(x_{a.c})
     &\mid&\ b < c;\ x \in (M \cup S)
@@ -250,7 +250,7 @@ $M$ is the set of message types, and $S$ is the set of service types.
 
 \subsubsection{Non-fixed port identifier assignment recommendations}
 
-For non-fixed port identifiers assigned
+For non-fixed port identifiers
 it is recommended to ensure that any port identifier of a given kind (subject or service)
 is only used with one major version of one data type.
 

--- a/specification/dsdl/versioning.tex
+++ b/specification/dsdl/versioning.tex
@@ -266,7 +266,7 @@ the numeric value of a port-ID may refer to different data types if they are of 
 \subsubsection{Data type version selection}
 
 DSDL compilers should compile every available data type version separately,
-allowing the application to choose from all available major and minor version combination.
+allowing the application to choose from all available major and minor version combinations.
 
 When emitting a transfer, the major version of the data type is chosen at the discretion of the application.
 The minor version should be the newest available one under the chosen major version.

--- a/specification/introduction/introduction.tex
+++ b/specification/introduction/introduction.tex
@@ -27,7 +27,8 @@ print('Hello world!')
 A byte is a group of eight (8) bits.
 
 Textual patterns are specified using the standard
-POSIX Extended Regular Expression (ERE) syntax.
+POSIX Extended Regular Expression (ERE) syntax;
+the character set is ASCII and patterns are case sensitive, unless explicitly specified otherwise.
 
 Type parametrization expressions use subscript notation,
 where the parameter is specified in the subscript enclosed in angle brackets:

--- a/specification/introduction/introduction.tex
+++ b/specification/introduction/introduction.tex
@@ -143,7 +143,7 @@ the set of public regulated data type definitions can be modified only in the fo
     \item An existing data type or a particular major version of it can be declared deprecated.
     \begin{itemize}
         \item Once declared deprecated, the data type will be maintained for at least two more years.
-        After this period, its regulated fixed port ID (if defined) may be reused for
+        After this period, its regulated fixed port-ID (if defined) may be reused for
         an incompatible data type definition.
         The maintainers will be striving to postpone the reuse of regulated port identifiers as much as
         possible in order to minimize the possibility of unintended conflicts.

--- a/specification/introduction/introduction.tex
+++ b/specification/introduction/introduction.tex
@@ -24,7 +24,18 @@ All such code is distributed under the same license as this specification, unles
 print('Hello world!')
 \end{minted}
 
-It is assumed that a byte always contains eight bits.
+A byte is a group of eight (8) bits.
+
+Textual patterns are specified using the standard
+POSIX Extended Regular Expression (ERE) syntax.
+
+Type parametrization expressions use subscript notation,
+where the parameter is specified in the subscript enclosed in angle brackets:
+$\texttt{type}_\texttt{<parameter>}$.
+
+Numbers are represented in base-10 by default.
+If a different base is used, it is specified after the number in the subscript:
+$\text{BADC0FFEE}_{16} = 50159747054$, $10101_2$.
 
 \section{Design principles}
 

--- a/specification/introduction/introduction.tex
+++ b/specification/introduction/introduction.tex
@@ -88,15 +88,17 @@ $\text{BADC0FFEE}_{16} = 50159747054$, $10101_2$.
 
 \section{Capabilities}
 
-UAVCAN-based networks can accommodate up to 128 nodes on the same logical bus.
+The maximum number of nodes per logical network is dependent on the transport protocol in use,
+but it is guaranteed to be not less than 128.
 
-UAVCAN supports an unlimited number of data types, which can be defined by the specification (such definitions
-are called ``standard data types'') or by others for private use or for public release
-(in which case they are said to be ``application-specific'' or ``vendor-specific'').
+UAVCAN supports an unlimited number of composite data types,
+which can be defined by the specification (such definitions are called ``standard data types'')
+or by others for private use or for public release
+(in which case they are said to be ``application-specific'' or ``vendor-specific''; these terms are equivalent).
 There can be up to 256 major versions of a data type, and up to 256 minor versions per major version.
 More information is provided in chapter \ref{sec:dsdl}.
 
-UAVCAN supports 65536 message subject identifiers for publish/subscribe exchanges,
+UAVCAN supports 32768 message subject identifiers for publish/subscribe exchanges,
 512 service identifiers for remote procedure call exchanges,
 and at least 8 anonymous message subject identifiers for certain special features such as plug-and-play support.
 A small subset of these identifiers is reserved for the core standard and for publicly released vendor-specific types.
@@ -112,23 +114,25 @@ Non-redundant, doubly-redundant and triply-redundant transports are supported.
 More information on the physical layer and standardized physical connectivity options
 is provided in chapter \ref{sec:physical_layer}.
 
-\section{Maintenance of the standard data type set}
+\section{Public regulated data types}
 
-The UAVCAN maintainers are charged with advancing the standard data type set based on input from adopters.
-This feedback is gathered via the official discussion
-forum\footnote{Please refer to \href{http://uavcan.org}{uavcan.org}.}
-which is open to the general public.
+This section talks about general management policies.
+The related technical aspects are covered in chapters~\ref{sec:basic_concepts} and~\ref{sec:dsdl}.
 
-The set of standard data type definitions\footnote{The \emph{data structure description language} (DSDL) and
-related concepts are described in chapter \ref{sec:dsdl}.} is an integral part of the specification;
-however, there is only a small set of required data types needed to implement the protocol.
+The UAVCAN maintainers are charged with maintaining and advancing the set of
+public regulated data types based on the input from adopters.
+This feedback is gathered via the online discussion and collaboration websites
+which are open to the general public and available through \href{http://uavcan.org}{uavcan.org}.
+
+The set of standard data types is a subset of public regulated data types and is an integral part of the specification;
+however, there is only a very small subset of required standard data types needed to implement the protocol.
 A larger set of optional data types are defined to create a standardized data exchange environment
 supporting the interoperability of COTS\footnote{Commercial off-the-shelf equipment.}
 equipment manufactured by different vendors.
 See chapter \ref{sec:application_layer} for more information.
 
 Within the same major version of the specification,
-the set of regulated data type definitions can be modified only in the following ways:
+the set of public regulated data type definitions can be modified only in the following ways:
 
 \begin{itemize}
     \item A new data type can be added, as long as it doesn't conflict with any of the existing data types.
@@ -139,7 +143,8 @@ the set of regulated data type definitions can be modified only in the following
     \item An existing data type or a particular major version of it can be declared deprecated.
     \begin{itemize}
         \item Once declared deprecated, the data type will be maintained for at least two more years.
-        After this period, its regulated port ID (if defined) may be reused for an incompatible data type definition.
+        After this period, its regulated fixed port ID (if defined) may be reused for
+        an incompatible data type definition.
         The maintainers will be striving to postpone the reuse of regulated port identifiers as much as
         possible in order to minimize the possibility of unintended conflicts.
 
@@ -147,8 +152,7 @@ the set of regulated data type definitions can be modified only in the following
     \end{itemize}
 \end{itemize}
 
-A link to the repository containing the set of default DSDL definitions can be found on the official
-website\footnote{\href{http://uavcan.org}{uavcan.org}}.
+A link to the repository containing the set of default DSDL definitions can be found on the official website.
 
 \section{Referenced sources}
 

--- a/specification/transport_layer/can.tex
+++ b/specification/transport_layer/can.tex
@@ -121,7 +121,7 @@ for message transfers and service transfers, respectively.
     Anonymous message   & 1     & $\{0, 1\}$ (any)  & Zero for regular (non-anonymous) message transfers.
                                                       One for anonymous message transfers. \\
 
-    Subject ID          & 16    & $[0, 32767]$ (any) & Subject identifier of the current message.
+    Subject ID          & 16    & $[0, 32767]$       & Subject identifier of the current message.
                                                        The most significant bit is always zero. \\
 
     Source node ID      & 7     & $[0, 127]$ (any)  & Node ID of the origin.

--- a/specification/transport_layer/can.tex
+++ b/specification/transport_layer/can.tex
@@ -33,7 +33,7 @@ for message transfers and service transfers, respectively.
             \multirow{2}{*}{\textbf{Message}} &
             \multicolumn{4}{c|}{Service, not message} &
             \multicolumn{5}{c|}{Anonymous message} &
-            \multicolumn{12}{c|}{\multirow{2}{*}{Subject ID}} &
+            \multicolumn{12}{c|}{\multirow{2}{*}{Subject-ID}} &
             \multicolumn{8}{c|}{Protocol version}
             \\\cline{2-4} \cline{7-10} \cline{23-29}
 
@@ -43,7 +43,7 @@ for message transfers and service transfers, respectively.
             &
             &
             \multicolumn{16}{c|}{} &
-            \multicolumn{7}{c|}{Source node ID} &
+            \multicolumn{7}{c|}{Source node-ID} &
             \\
 
             \textbf{Values} &
@@ -74,7 +74,7 @@ for message transfers and service transfers, respectively.
             \multicolumn{4}{c|}{Service, not message} &
             \multicolumn{5}{c|}{Request, not response} &
             \multicolumn{5}{c|}{} &
-            \multicolumn{7}{c|}{\multirow{2}{*}{Destination node ID}} &
+            \multicolumn{7}{c|}{\multirow{2}{*}{Destination node-ID}} &
             \multicolumn{8}{c|}{Protocol version}
             \\\cline{2-4} \cline{7-10} \cline{23-29}
 
@@ -82,9 +82,9 @@ for message transfers and service transfers, respectively.
             \multicolumn{3}{c|}{Priority} &
             \cellcolor{red} &
             &
-            \multicolumn{9}{c|}{Service ID} &
+            \multicolumn{9}{c|}{Service-ID} &
             \multicolumn{7}{c|}{} &
-            \multicolumn{7}{c|}{Source node ID} &
+            \multicolumn{7}{c|}{Source node-ID} &
             \\
 
             \textbf{Values} &
@@ -121,10 +121,10 @@ for message transfers and service transfers, respectively.
     Anonymous message   & 1     & $\{0, 1\}$ (any)  & Zero for regular (non-anonymous) message transfers.
                                                       One for anonymous message transfers. \\
 
-    Subject ID          & 16    & $[0, 32767]$       & Subject identifier of the current message.
+    Subject-ID          & 16    & $[0, 32767]$       & Subject identifier of the current message.
                                                        The most significant bit is always zero. \\
 
-    Source node ID      & 7     & $[0, 127]$ (any)  & Node ID of the origin.
+    Source node-ID      & 7     & $[0, 127]$ (any)  & Node-ID of the origin.
                                                       For anonymous transfers, this field contains a pseudo-ID instead,
                                                       as described in section \ref{sec:can_source_node_pseudo_id}. \\
 
@@ -143,13 +143,13 @@ for message transfers and service transfers, respectively.
 
     Request not response& 1     & $\{0, 1\}$ (any)  & 1 for service request, 0 for service response. \\
 
-    Service ID          & 9     & $[0, 511]$ (any)  & Service ID of the encoded service object
+    Service-ID          & 9     & $[0, 511]$ (any)  & Service-ID of the encoded service object
                                                       (request or response). \\
 
-    Destination node ID & 7     & $[0, 127]$ (any)  & Node ID of the destination
+    Destination node-ID & 7     & $[0, 127]$ (any)  & Node-ID of the destination
                                                       (i.e., server for requests, client for responses). \\
 
-    Source node ID      & 7     & $[0, 127]$ (any)  & Node ID of the origin
+    Source node-ID      & 7     & $[0, 127]$ (any)  & Node-ID of the origin
                                                       (i.e., client for requests, server for responses). \\
 
     Protocol version    & 1     & $1$               & Protocol version, ignore frame
@@ -182,8 +182,8 @@ Service responses take precedence over service requests in order to make service
 and reduce the number of pending states in the system.
 
 Within the same type and the same priority level,
-transfers are prioritized according to the port ID\footnote{Subject ID or service ID.}:
-transfers with lower port ID values preempt those with higher port ID values.
+transfers are prioritized according to the port-ID\footnote{Subject-ID or service-ID.}:
+transfers with lower port-ID values preempt those with higher port-ID values.
 
 \begin{remark}
     Mnemonics for transfer priority levels are provided in section \ref{sec:transfer_prioritization},
@@ -203,16 +203,16 @@ transfers with lower port ID values preempt those with higher port ID values.
     \end{UAVCANSimpleTable}
 \end{remark}
 
-\subsubsection{Source node ID field in anonymous message transfers}\label{sec:can_source_node_pseudo_id}
+\subsubsection{Source node-ID field in anonymous message transfers}\label{sec:can_source_node_pseudo_id}
 
 CAN bus does not allow different nodes to transmit CAN frames with different data field values under the same CAN ID.
-Owing to the fact that the CAN ID includes the node ID value of the transmitting node,
+Owing to the fact that the CAN ID includes the node-ID value of the transmitting node,
 this restriction does not affect regular UAVCAN transfers.
 However, anonymous message transfers would violate this restriction,
-because they don't have a unique node ID.
+because they don't have a unique node-ID.
 
 In order to work around this problem,
-UAVCAN requires that the source node ID field of anonymous messages\footnote{Source node identifier
+UAVCAN requires that the source node-ID field of anonymous messages\footnote{Source node identifier
 is not defined for anonymous message transfers; see table \ref{table:common_transfer_properties}.}
 is initialized with a pseudorandom \emph{pseudo-ID value},
 and defines special logic for handling CAN bus errors during transmission of anonymous frames.
@@ -274,7 +274,7 @@ The extra byte contains certain metadata for the needs of the transport layer.
 It is named the \emph{tail byte}, and as the name suggests, it is always situated
 at the very last byte of the data field of every CAN frame.
 The tail byte contains four fields: \emph{start of transfer}, \emph{end of transfer},
-\emph{toggle bit}, and the transfer ID (described earlier in the section \ref{sec:transfer_id}).
+\emph{toggle bit}, and the transfer-ID (described earlier in the section \ref{sec:transfer_id}).
 The placement of the fields and their usage for single-frame and multi-frame transfers
 are documented in the table \ref{table:can_tail_byte}.
 
@@ -292,14 +292,14 @@ are documented in the table \ref{table:can_tail_byte}.
 
     4   &               & \multicolumn{2}{c|}{} \\
     3   &               & \multicolumn{2}{c|}{Modulo 32 (range [0, 31])} \\
-    2   & Transfer ID   & \multicolumn{2}{c|}{section \ref{sec:transfer_id}} \\
+    2   & Transfer-ID   & \multicolumn{2}{c|}{section \ref{sec:transfer_id}} \\
     1   &               & \multicolumn{2}{c|}{} \\
     0   &               & \multicolumn{2}{c|}{\footnotesize{(least significant bit)}} \\
     \hline
 \end{tabu}
 \end{table}
 
-The transfer ID field is populated according to the specification provided in the section \ref{sec:transfer_id}.
+The transfer-ID field is populated according to the specification provided in the section \ref{sec:transfer_id}.
 The usage of this field is independent of the type of the transfer.
 
 For single-frame transfers, the fields start-of-transfer, end-of-transfer, and the toggle bit
@@ -307,7 +307,7 @@ are all set to~1.
 
 For multi-frame transfers, the fields start-of-transfer and end-of-transfer
 are used to state the boundaries of the current transfer as described in the table.
-The transfer ID value is identical for all frames of a multi-frame transfer.
+The transfer-ID value is identical for all frames of a multi-frame transfer.
 
 The toggle bit, as described in the section \ref{sec:toggle_bit}, serves
 two main purposes: CAN frame deduplication and protocol version detection.

--- a/specification/transport_layer/transport_layer.tex
+++ b/specification/transport_layer/transport_layer.tex
@@ -34,7 +34,7 @@ All other nodes remain unaffected by such transmission and take no part in the a
 \subsubsection{Message and service transfers}
 
 A \emph{message transfer} is a broadcast transfer that contains a serialized message and its
-metadata\footnote{Such as the subject ID and the source node ID.}.
+metadata\footnote{Such as the subject-ID and the source node-ID.}.
 
 A \emph{service transfer} is a unicast transfer that contains either a service request or a service response
 with related metadata.
@@ -63,12 +63,12 @@ The properties listed in the table \ref{table:common_transfer_properties} are co
 \begin{UAVCANSimpleTable}{Common transfer properties}{|l X|}\label{table:common_transfer_properties}
     Property        & Description \\
     Payload         & The serialized object. \\
-    Port ID         & A numerical identifier that indicates how the data should be processed.
-                      This is the subject ID for message transfers and service ID for service transfers. \\
-    Source node ID  & The node ID of the transmitting node (excepting anonymous message transfers). \\
+    Port-ID         & A numerical identifier that indicates how the data should be processed.
+                      This is the subject-ID for message transfers and service-ID for service transfers. \\
+    Source node-ID  & The node-ID of the transmitting node (excepting anonymous message transfers). \\
     Priority        & A non-negative integer value that defines the transfer urgency.
                       Higher priority transfers can preempt lower priority transfers. \\
-    Transfer ID     & A small overflowing integer that increments with every transfer
+    Transfer-ID     & A small overflowing integer that increments with every transfer
                       of this data type from a given node. \\
 \end{UAVCANSimpleTable}
 
@@ -80,21 +80,21 @@ A published message is carried by a single message transfer that contains the se
 A published message does not contain any additional fields besides those listed in the table
 \ref{table:common_transfer_properties}.
 
-In order to publish a message, the publishing node must have a node ID that is unique within the network.
+In order to publish a message, the publishing node must have a node-ID that is unique within the network.
 An exception applies to \emph{anonymous message publications}.
 
 \subsubsection{Anonymous message publication}\label{sec:transport_anonymous_message_publication}
 
-An anonymous message transfer is a transfer that can be sent from a node that does not have a node ID.
+An anonymous message transfer is a transfer that can be sent from a node that does not have a node-ID.
 This kind of message transfer is especially useful for facilitation of \emph{plug-and-play nodes}
 (a high-level concept that is reviewed in detail in chapter \ref{sec:application_layer}).
 
-A node that does not have a node ID is said to be in \emph{passive mode}.
+A node that does not have a node-ID is said to be in \emph{passive mode}.
 Passive nodes are unable to initiate regular data exchanges,
 but they can listen to the transfers exchanged over the bus,
 and they can emit anonymous message transfers.
 
-An anonymous message has the same properties as a regular message, except for the source node ID.
+An anonymous message has the same properties as a regular message, except for the source node-ID.
 
 An anonymous transfer can only be a single-frame transfer. Multi-frame anonymous message transfers are not allowed.
 This restriction must be kept in mind when designing message data types
@@ -121,23 +121,23 @@ A service request transfer is sent from the invoking node -- \emph{client node} 
 that provides the service -- \emph{server node}.
 Upon handling the request, the server node responds to the client node with a service response transfer.
 The client will match the response with the corresponding request by comparing the following values:
-server node ID, service ID, and the transfer ID.
+server node-ID, service-ID, and the transfer-ID.
 
 The tables \ref{table:service_request_transfer_properties} and \ref{table:service_response_transfer_properties}
 describe the properties of service request and service response transfers, respectively.
 
-Both the client and the server must have node ID values that are unique within the network;
+Both the client and the server must have node-ID values that are unique within the network;
 service invocation is not available to passive nodes.
 The client and the server must be two distinct nodes.
 
 \begin{UAVCANSimpleTable}{Service request transfer properties}{|l X|}\label{table:service_request_transfer_properties}
     Property                        & Description \\
     Payload                         & The serialized service request object. \\
-    Service ID                      & See the table \ref{table:common_transfer_properties}. \\
-    Source node ID                  & The node ID of the client (the invoking node). \\
-    Destination node ID             & The node ID of the server (the invoked node). \\
+    Service-ID                      & See the table \ref{table:common_transfer_properties}. \\
+    Source node-ID                  & The node-ID of the client (the invoking node). \\
+    Destination node-ID             & The node-ID of the server (the invoked node). \\
     Priority                        & See the table \ref{table:common_transfer_properties}. \\
-    Transfer ID                     & An integer value that:
+    Transfer-ID                     & An integer value that:
         \begin{enumerate}
             \item allows the server to distinguish the request from other requests from the same client;
             \item allows the client to match the response with its request.
@@ -147,11 +147,11 @@ The client and the server must be two distinct nodes.
 \begin{UAVCANSimpleTable}{Service response transfer properties}{|l X|}\label{table:service_response_transfer_properties}
     Property                        & Description \\
     Payload                         & The serialized service response object. \\
-    Service ID                      & Same value as in the request transfer. \\
-    Source node ID                  & The node ID of the server (the invoked node). \\
-    Destination node ID             & The node ID of the client (the invoking node). \\
+    Service-ID                      & Same value as in the request transfer. \\
+    Source node-ID                  & The node-ID of the server (the invoked node). \\
+    Destination node-ID             & The node-ID of the client (the invoking node). \\
     Priority                        & Same value as in the request transfer. \\
-    Transfer ID                     & Same value as in the request transfer. \\
+    Transfer-ID                     & Same value as in the request transfer. \\
 \end{UAVCANSimpleTable}
 
 \subsubsection{Service timing requirements}
@@ -230,24 +230,24 @@ delaying their transmission until there are no more higher priority transfers to
 Transfer emission and reception processes rely on the concept of \emph{transfer descriptor}.
 
 A transfer descriptor is a set of properties that identify a particular set of transfers that originate
-from the same source node, share the same port ID, same kind (message or service), and are addressed to the same
+from the same source node, share the same port-ID, same kind (message or service), and are addressed to the same
 destination node (the latter applies only to unicast transfers).
 
 The properties that constitute a transfer descriptor are listed below:
 
 \begin{itemize}
     \item Transfer kind (message or service).
-    \item Port ID (subject ID for message transfers, service ID for service transfers).
-    \item Source node ID.
-    \item Destination node ID (only for service transfers).
+    \item Port-ID (subject-ID for message transfers, service-ID for service transfers).
+    \item Source node-ID.
+    \item Destination node-ID (only for service transfers).
 \end{itemize}
 
 For convenience, two derived definitions are introduced.
 Their objective is to simplify the description of transfer reception and emission logic that appears later in this
 specification.
 \begin{description}
-    \item[Emitted transfer descriptor] -- a transfer descriptor where the source node ID equals the local node's ID.
-    \item[Received transfer descriptor] -- a transfer descriptor where the destination node ID equals
+    \item[Emitted transfer descriptor] -- a transfer descriptor where the source node-ID equals the local node's ID.
+    \item[Received transfer descriptor] -- a transfer descriptor where the destination node-ID equals
     the local node's ID (for service transfers) or is not defined (for message transfers).
 \end{description}
 
@@ -259,14 +259,14 @@ hence, its contribution to the worst case data processing load should be careful
 
 \begin{remark}
     From the above definition of transfer descriptor it is easy to derive that for any
-    message subject ID or any service subject ID the maximum number of transfer descriptors
+    message subject-ID or any service subject-ID the maximum number of transfer descriptors
     that can be observed by the local node will never exceed the number of nodes on the bus minus
     one\footnote{The local node cannot exchange data with itself, hence minus one.}.
     If the number of nodes on the bus cannot be known in advance, it can be considered to equal 128,
     which is the maximum node capacity of a UAVCAN bus.
 
     The total number of distinct transfer descriptors that can be observed by a node on any valid UAVCAN bus
-    is a product of the number of distinct port ID values utilized by the node and the number of other nodes on the bus.
+    is a product of the number of distinct port-ID values utilized by the node and the number of other nodes on the bus.
 
     The transport emission and reception logic defined later in this specification relies on data structures
     indexed by transfer descriptor values.
@@ -276,39 +276,39 @@ hence, its contribution to the worst case data processing load should be careful
 
 \section{Transfer emission}
 
-\subsection{Transfer ID computation}\label{sec:transfer_id}
+\subsection{Transfer-ID computation}\label{sec:transfer_id}
 
-The \emph{transfer ID} is a small unsigned integer value in the range from 0 to 31, inclusive,
+The \emph{transfer-ID} is a small unsigned integer value in the range from 0 to 31, inclusive,
 that is provided for every transfer.
-This value is crucial for many aspects of UAVCAN communication\footnote{One might be tempted to use the transfer ID
+This value is crucial for many aspects of UAVCAN communication\footnote{One might be tempted to use the transfer-ID
 value for temporal synchronization of parallel message streams originating from the same node,
-where messages bearing the same transfer ID value are supposed to correspond to the same moment of time.
+where messages bearing the same transfer-ID value are supposed to correspond to the same moment of time.
 Such use is strongly discouraged because it is impossible to detect if one node is more than
 32 messages behind another.
 If temporal synchronization is necessary, explicit time stamping should be used instead.};
 specifically:
 \begin{description}
-    \item[Message sequence monitoring] - the continuously increasing transfer ID allows receiving nodes to
+    \item[Message sequence monitoring] - the continuously increasing transfer-ID allows receiving nodes to
     detect lost messages and detect when a message stream from any remote node is interrupted.
 
-    \item[Service response matching] - when a server responds to a request, it uses the same transfer ID for the
+    \item[Service response matching] - when a server responds to a request, it uses the same transfer-ID for the
     response as in the request,
     allowing any node to emit concurrent requests to the same server while being able to
     match each response with the corresponding request.
 
     \item[Transport frame deduplication] - for single-frame transfers,
-    the transfer ID allows receiving nodes to work around the transport
+    the transfer-ID allows receiving nodes to work around the transport
     frame duplication problem\footnote{This is a well-known issue that can be observed with certain
     transports such as CAN bus -- a frame that appears valid to the receiver may under certain
     (rare) conditions appear invalid to the transmitter, triggering the latter to retransmit the frame,
     in which case it will be duplicated on the side of the receiver.
-    Sequence counting mechanisms such as the transfer ID or the toggle bit (both of which are used in UAVCAN)
+    Sequence counting mechanisms such as the transfer-ID or the toggle bit (both of which are used in UAVCAN)
     allow applications to circumvent this problem.} (multi-frame transfers combat the frame duplication
     problem using the toggle bit, which is introduced later).
 
     \item[Multi-frame transfer reassembly] - more info is provided in section \ref{sec:transfer_reception}.
 
-    \item[Automatic management of redundant interfaces] - the transfer ID parameter allows the UAVCAN protocol
+    \item[Automatic management of redundant interfaces] - the transfer-ID parameter allows the UAVCAN protocol
     stack to perform automatic switchover to a back-up interface shall the primary interface fail.
     The switchover logic can be completely transparent to the application, joining several independent
     redundant physical transports into a highly reliable single virtual communication channel.
@@ -319,21 +319,21 @@ For service response transfers this value must be directly copied from the corre
 
 Every node that is interested in emitting transfers must maintain a mapping
 (or a similar functionally equivalent static structure\footnote{For example, simple static variables.})
-from emitted transfer descriptors (section \ref{sec:transfer_descriptor}) to transfer ID counters.
-This mapping is referred to as the \emph{emitted transfer ID map}.
+from emitted transfer descriptors (section \ref{sec:transfer_descriptor}) to transfer-ID counters.
+This mapping is referred to as the \emph{emitted transfer-ID map}.
 
-Whenever a node needs to emit a transfer, it will query its transfer ID map for the appropriate transfer descriptor.
-If the map does not contain such entry, a new entry will be created with the transfer ID counter initialized to zero.
-The node will use the current value of the transfer ID from the map for the transfer,
+Whenever a node needs to emit a transfer, it will query its transfer-ID map for the appropriate transfer descriptor.
+If the map does not contain such entry, a new entry will be created with the transfer-ID counter initialized to zero.
+The node will use the current value of the transfer-ID from the map for the transfer,
 and then the value stored in the map will be incremented by one.
-When the stored transfer ID exceeds its maximum value, it will roll over to zero.
+When the stored transfer-ID exceeds its maximum value, it will roll over to zero.
 
 It is expected that some nodes will need to emit certain transfers aperiodically or on an ad-hoc basis,
-thereby creating unused entries in the emitted transfer ID map.
+thereby creating unused entries in the emitted transfer-ID map.
 If such aperiodic or ad-hoc transfers are of interest,
 the worst case number of unused entries can be determined statically as a function of the number of
 port identifiers used and the number of addressed nodes on the bus (the latter applies to services only).
-Nodes are not allowed to remove any entries from the transfer ID map as long as they are running.
+Nodes are not allowed to remove any entries from the transfer-ID map as long as they are running.
 
 \subsection{Single frame transfers}
 
@@ -474,7 +474,7 @@ int main()
 
 The toggle bit is a property defined at the transport frame level.
 Its purpose is to detect and avoid transport frame duplication errors in multi-frame
-transfers\footnote{In single-frame transfers, transport frame deduplication is based on the transfer ID counter.}.
+transfers\footnote{In single-frame transfers, transport frame deduplication is based on the transfer-ID counter.}.
 
 The toggle bit of the first transport frame of a multi-frame transfer must be set to one.
 The toggle bits of the following transport frames of the transfer must alternate,
@@ -515,10 +515,10 @@ See section \ref{sec:phy_non_uniform_transport_redundancy}.
 
 \section{Transfer reception}\label{sec:transfer_reception}
 
-\subsection{Transfer ID comparison}\label{sec:transfer_id_forward_distance}
+\subsection{Transfer-ID comparison}\label{sec:transfer_id_forward_distance}
 
-The following explanation relies on the concept of the \emph{transfer ID forward distance}.
-Transfer ID forward distance $F$ is a function of two transfer ID values,
+The following explanation relies on the concept of the \emph{transfer-ID forward distance}.
+Transfer-ID forward distance $F$ is a function of two transfer-ID values,
 $A$ and $B$, that defines the number of increment operations that need to be applied to
 $A$ so that $A^\prime{} = B$, assuming modulo 32 arithmetic\footnote{%
     For example:
@@ -529,13 +529,13 @@ $A$ so that $A^\prime{} = B$, assuming modulo 32 arithmetic\footnote{%
     $A=31, B=0, F\rightarrow1$.
 }:
 $$A + F = B \quad (\bmod{}\ 32)$$
-The \emph{half range} of transfer ID is 16.
+The \emph{half range} of transfer-ID is 16.
 
-The following code sample provides an example implementation of the transfer ID comparison algorithm in C++.
+The following code sample provides an example implementation of the transfer-ID comparison algorithm in C++.
 
 \begin{minipage}{0.9\textwidth}  % Mini page is needed to prevent page breaks within the snippet
 \begin{minted}{cpp}
-// UAVCAN transfer ID forward distance computation algorithm implemented in C++.
+// UAVCAN transfer-ID forward distance computation algorithm implemented in C++.
 // License: CC0, no copyright reserved.
 
 #include <cstdint>
@@ -599,7 +599,7 @@ and section \ref{sec:transfer_reception_state_update_non_redundant} for non-redu
 It is expected that some transfers will be aperiodic or ad-hoc,
 which implies that the receiver map may over time accumulate receiver states that are no longer used.
 Therefore, nodes are allowed, but not required, to remove any receiver state from the receiver map
-as soon as the state reaches the \emph{transfer ID timeout condition}\footnote{Such behavior is
+as soon as the state reaches the \emph{transfer-ID timeout condition}\footnote{Such behavior is
 not recommended for hard real-time applications, where deterministic static look-up tables
 should be preferred instead.},
 as defined in section \ref{sec:transfer_id_timeout_condition}.
@@ -611,7 +611,7 @@ require any periodic background maintenance activities.
 \begin{UAVCANSimpleTable}{Transfer reception state variables}{|l X|}
     State               & Description \label{table:transfer_receiver_state_variables} \\
     Transfer payload    & Useful payload byte sequence; extended upon reception of new matching transport frames. \\
-    Transfer ID         & The transfer ID value of the next expected transport frame. Section \ref{sec:transfer_id}. \\
+    Transfer-ID         & The transfer-ID value of the next expected transport frame. Section \ref{sec:transfer_id}. \\
     Next toggle bit     & Expected value of the toggle bit in the next transport frame.
                           Section \ref{sec:toggle_bit}. \\
     Transfer timestamp  & The local monotonic timestamp sampled when the first frame of the transfer arrived.
@@ -629,9 +629,9 @@ Upon reset, the receiver state will meet the following conditions:
 
 \begin{itemize}
     \item The transfer payload buffer is empty.
-    \item The transfer ID state matches the actual transfer ID value from the newly received transfer,
+    \item The transfer-ID state matches the actual transfer-ID value from the newly received transfer,
     unless this is a non-first frame of a multi-frame transfer.
-    In the latter case, the transfer ID state will match the received transfer ID value incremented by one.
+    In the latter case, the transfer-ID state will match the received transfer-ID value incremented by one.
     \item The toggle bit is set to its initial state (section \ref{sec:toggle_bit}).
     \item The transfer timestamp matches the reception timestamp from the transport frame.
     \item The interface index matches the index of the interface that the new frame was received from
@@ -643,25 +643,25 @@ A receiver state must be reset when any of the following conditions are met:
 \begin{itemize}
     \item A new receiver state instance is created.
 
-    \item A transfer ID timeout condition is reached (section \ref{sec:transfer_id_timeout_condition}).
+    \item A transfer-ID timeout condition is reached (section \ref{sec:transfer_id_timeout_condition}).
 
     \item A first frame of a transfer (either a multi-frame or a single-frame; in the latter case, the same frame
     would also be the last frame of the transfer) is received from the same interface as the previous frame
     (does not apply to non-redundantly interfaced nodes),
-    and the transfer ID forward distance (section \ref{sec:transfer_id_forward_distance}) from the received
-    transfer ID to the stored transfer ID is greater than one.
+    and the transfer-ID forward distance (section \ref{sec:transfer_id_forward_distance}) from the received
+    transfer-ID to the stored transfer-ID is greater than one.
 
     \item Only for redundantly interfaced nodes: A first frame of a transfer is received,
     an interface switchover condition is reached (section \ref{sec:transfer_interface_switchover_condition}),
-    and the transfer ID forward distance from the stored transfer ID to the received transfer ID is
-    less than the transfer ID half range (section \ref{sec:transfer_id_forward_distance}).
+    and the transfer-ID forward distance from the stored transfer-ID to the received transfer-ID is
+    less than the transfer-ID half range (section \ref{sec:transfer_id_forward_distance}).
 \end{itemize}
 
-\subsubsection{Transfer ID timeout condition}\label{sec:transfer_id_timeout_condition}
+\subsubsection{Transfer-ID timeout condition}\label{sec:transfer_id_timeout_condition}
 
-A state is said to have reached the transfer ID timeout condition
+A state is said to have reached the transfer-ID timeout condition
 if the last matching transfer was seen more than 2 (two) seconds ago.
-When this condition is reached, the receiver must accept the next transfer disregarding its transfer ID value.
+When this condition is reached, the receiver must accept the next transfer disregarding its transfer-ID value.
 
 Nodes are allowed to use different timeout values, if that is believed to benefit the application.
 If a different timeout value is used, it must be explicitly documented.
@@ -669,7 +669,7 @@ If a different timeout value is used, it must be explicitly documented.
 Low timeout values increase the risk of undetected transfer duplication when such transfers are significantly
 delayed due to bus congestion, which is possible with very low-priority transfers when the bus utilization is high.
 
-High timeout values increase the risk of an undetected transfer loss when a remote node suffers an emitted transfer ID
+High timeout values increase the risk of an undetected transfer loss when a remote node suffers an emitted transfer-ID
 map state loss (e.g., due to the whole node being restarted).
 However, the effects of such a transfer loss caused by a loss of state on a remote node
 are always constrained to the first transfer only.
@@ -683,7 +683,7 @@ the previous transfer was received from.
 The condition is reached when the last matching transfer was successfully received more than
 $T_\text{switch}$ seconds ago. The value of $T_\text{switch}$ should not exceed the reception transfer
 ID timeout, as defined in section \ref{sec:transfer_id_timeout_condition},
-because if $T_\text{switch}$ were to exceed the transfer ID timeout, an interface switchover would be
+because if $T_\text{switch}$ were to exceed the transfer-ID timeout, an interface switchover would be
 performed by the normal receiver state reset procedure, rendering $T_\text{switch}$ useless.
 
 The actual value of $T_\text{switch}$ can be either a constant chosen by the designer according
@@ -691,12 +691,12 @@ to the application requirements (e.g., the maximum recovery time in the event of
 or the protocol stack can estimate this value automatically by analyzing the transfer intervals.
 
 Nodes are required to let the first interface time out before using the next one because the
-transfer ID field is expected to wrap around frequently (every 32 transfers).
+transfer-ID field is expected to wrap around frequently (every 32 transfers).
 Different interfaces are expected to exhibit different latencies even in a properly functioning system,
 especially if the system contains both redundantly-interfaced and non-redundantly-interfaced nodes.
 If the latency of a backup interface relative to the primary interface exceeds 32 transfer intervals,
 and receiving nodes were to be allowed to switch between interfaces freely disregarding the timeout,
-the receiving node would skip the whole period of transfer IDs (32 transfers will be lost).
+the receiving node would skip the whole period of transfer-IDs (32 transfers will be lost).
 The problem would primarily affect low-priority transfers where large latencies are more likely.
 
 \subsection{State update in a redundant interface configuration}
@@ -762,7 +762,7 @@ function receiveFrame(frame)
 
     if (frame.transfer_id != current_transfer_id)
     {
-        return;  // Unexpected transfer ID, ignore
+        return;  // Unexpected transfer-ID, ignore
     }
 
     if (first_frame)
@@ -835,7 +835,7 @@ function receiveFrame(frame)
 
     if (frame.transfer_id != current_transfer_id)
     {
-        return;  // Unexpected transfer ID, ignore
+        return;  // Unexpected transfer-ID, ignore
     }
 
     if (first_frame)


### PR DESCRIPTION
This PR is against the changeset of #46. It contains minor corrections and fixes across the whole specification, mostly focused on minor clarifications and fixing incorrect term usage. The bulk of the changes is due to the automatic replacement of patterns like `node ID` to `node-ID`. I have also updated the DSDL rendering script to use PyDSDL v0.5.0 and fixed its version to prevent future breakage.

Originally I planned to postpone opening this PR until the previous one is accepted, but then I noticed that the old PR is likely to raise questions which are already addressed here, so it seemed sensible to come forward with my changes even if that might disrupt the workflow somewhat.

The changes should be relatively easy to review in the source form right here on GitHub. This is not a WIP; if we agree on the changes, they should be merged immediately.