### PR TITLE
DSDL: un-reserve names "com" and "lpt"

### DIFF
--- a/specification/dsdl/grammar.tex
+++ b/specification/dsdl/grammar.tex
@@ -248,7 +248,7 @@ in this version of the DSDL specification, but this may change in the future.
     \texttt{prn}                                       &                    & Compatibility with Microsoft Windows \\
     \texttt{aux}                                       &                    & Compatibility with Microsoft Windows \\
     \texttt{nul}                                       &                    & Compatibility with Microsoft Windows \\
-    \texttt{com\textbackslash{}d?}                     & \texttt{com1}      & Compatibility with Microsoft Windows \\
-    \texttt{lpt\textbackslash{}d?}                     & \texttt{lpt}       & Compatibility with Microsoft Windows \\
+    \texttt{com\textbackslash{}d}                      & \texttt{com1}      & Compatibility with Microsoft Windows \\
+    \texttt{lpt\textbackslash{}d}                      & \texttt{lpt9}      & Compatibility with Microsoft Windows \\
     \texttt{\_.*\_}                                    & \texttt{\_offset\_}& Special-purpose intrinsic entities \\
 \end{UAVCANSimpleTable}


### PR DESCRIPTION
Per Microsoft, names "COM" and "LPT" are allowed: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file

This change does not break anything.