### PR TITLE
Timing recommendations without overspecification.

### DIFF
--- a/specification/application/conventions.tex
+++ b/specification/application/conventions.tex
@@ -15,25 +15,15 @@ which is guaranteed to be above 127 for any transport.
 The two uppermost node-ID values are reserved for diagnostic and debugging tools;
 these node-ID values should not be used in fielded systems.
 
-\subsection{Timing constraints}
-
-\subsubsection{Recommended message publication timing constraints}
-
-Generally, it is recommended to abort a message transmission if it cannot be completed in 1 second.
-
-It is expected that high-frequency high-priority messages may opt for lower timeout values,
-whereas low-priority delayable data may opt for higher timeout values to account for network congestion.
-Refer to section~\ref{sec:transport_transfer_priority} on transfer prioritization.
-
-\subsubsection{Recommended service invocation timing constraints}
-
-It is recommended to abort a service transfer transmission if it cannot be completed in 1 second.
-It is recommended to stop waiting for a service response if it could not be received in the same amount of time;
-upon reaching this condition, the service request operation should be considered unsuccessful.
+\subsection{Service latency}
 
 If the server uses a significant part of the timeout period to process the request,
 the client might drop the request before receiving the response.
-It is recommended to ensure that the server will be able to process any request in less than 0.5 seconds.
+Servers should minimize the request processing time; that is,
+the time between reception of a service request transfer and
+the transmission of the corresponding service response transfer.
+
+The worst-case request processing time should be documented for each server-side service port.
 
 \subsection{Coordinate frames}
 

--- a/specification/transport/abstract.tex
+++ b/specification/transport/abstract.tex
@@ -626,7 +626,7 @@ The transmission timeout should be documented for each outgoing transfer port.
 
 \subsubsection{Pending service requests}
 
-In the case of cyclic transfer-ID transports (section \ref{sec:transport_transfer_id}),
+In the case of cyclic transfer-ID transports (section~\ref{sec:transport_transfer_id}),
 implementations should ensure that upon a transfer-ID overflow a service client session
 does not reuse the same transfer-ID value for more than one pending request simultaneously.
 

--- a/specification/transport/abstract.tex
+++ b/specification/transport/abstract.tex
@@ -610,6 +610,26 @@ A heterogeneous redundant transport shall meet \emph{either} of the following re
 
 \subsection{Transfer transmission}
 
+\subsubsection{Transmission timeout}
+
+The transport frames of a time-sensitive transfer whose payload has lost relevance due to
+its transmission being delayed should be removed from the transmission queue\footnote{%
+    Trailing transport frames of partially transmitted multi-frame transfers should be removed as well.
+    The objective of this recommendation is to ensure that obsolete data is not transmitted
+    as it may have adverse effects on the system.
+}.
+The time interval between the point where the transfer is constructed and the point where it is considered
+to have lost relevance is referred to as \emph{transmission timeout}.
+
+% "Output port" sounds better but this term is not defined.
+The transmission timeout should be documented for each outgoing transfer port.
+
+\subsubsection{Pending service requests}
+
+In the case of cyclic transfer-ID transports (section \ref{sec:transport_transfer_id}),
+implementations should ensure that upon a transfer-ID overflow a service client session
+does not reuse the same transfer-ID value for more than one pending request simultaneously.
+
 \subsubsection{Deterministic data loss mitigation}\label{sec:transport_deterministic_data_loss_mitigation}
 
 Performance of transport networks where the probability of a successful transfer delivery


### PR DESCRIPTION
With this change, the only concrete time value remaining in the specification is the transfer-ID timeout (2 seconds).

Origin:
- https://github.com/UAVCAN/specification/pull/68#discussion_r365042541
- https://github.com/UAVCAN/specification/pull/68#discussion_r366159070