### PR TITLE
Make Section Numbers Appear in PDF Bookmark Tree

### DIFF
--- a/specification/uavcandoc.cls
+++ b/specification/uavcandoc.cls
@@ -275,6 +275,9 @@
 \preto\listoftables{\hypersetup{linkcolor=black}         \setlength{\parskip}{0em}}
 \appto\listoftables{\hypersetup{linkcolor=colorhyperlink}\setlength{\parskip}{\DefaultParskip}}
 
+% Include section numbers in the pdf bookmark tree.
+\hypersetup{bookmarksnumbered}
+
 %
 % Table macros.
 %


### PR DESCRIPTION
By setting hyperref's `bookmarksnumbered` option, the generated pdf bookmark tree has section numbers prepended to the entries.

![image](https://user-images.githubusercontent.com/8170410/84058788-04565780-a9ba-11ea-8720-13ecfbc6111a.png)

This would close UAVCAN/specification#49.