### PR TITLE
Beta PR 2 of 2: delimited serialization

### DIFF
--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -472,3 +472,4 @@ DTH
 submodules
 Liskov
 deserializer
+BLS

--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -465,3 +465,8 @@ merchantability
 uncomment
 pydsdl
 github
+texer
+vscode
+extensionpack
+DTH
+submodules

--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -470,3 +470,5 @@ vscode
 extensionpack
 DTH
 submodules
+Liskov
+deserializer

--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -473,3 +473,4 @@ submodules
 Liskov
 deserializer
 BLS
+evolvable

--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -474,3 +474,4 @@ Liskov
 deserializer
 BLS
 evolvable
+Protobuf

--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ Without strict conventions in place, they quickly become unmanageable.
 - There shall be one blank line above and below a section header,
 unless the section header is at the top of the source file.
 - Multi-line content enclosed in curly braces should be indented.
-- If a list item spills on the next line, the spilled text should be indented on the same level with the first line.
+- If a list item spills on the next line, the spilled text should be indented on the same level with `\item`.
 
 ```tex
 \begin{itemize}
     \item This list item is sufficiently long to exceed the limit of 120 characters per line,
-          so it has to spill onto the next line.
-          The spilled part is indented correctly.
+    so it has to spill onto the next line.
+    The spilled part is indented correctly.
 
     \item Another item.
 \end{itemize}

--- a/README.md
+++ b/README.md
@@ -102,10 +102,8 @@ A GNU/Linux-based operating system is assumed.
 The described instructions may be valid for other operating systems but this is not guaranteed.
 
 In order to compile the document, install TeX Live
-(Ubuntu packages: [`texlive-full`](https://packages.ubuntu.com/xenial/texlive-full) and `lyx`),
-and make sure that the version of pdfLaTeX is `3.14159265-2.6-1.40.16`.
-Any other version may miscompile the document with subtle typographical defects.
-Install the Python packages listed in `requirements.txt`.
+(Ubuntu packages: [`texlive-full`](https://packages.ubuntu.com/xenial/texlive-full) and `lyx`)
+and the Python packages listed in `requirements.txt`.
 
 When done, run `./compile.sh`.
 
@@ -131,6 +129,6 @@ the `.vscode/spellright.dict` to squelch bogus spelling errors from Spellright.
 
 #### L33t IDE Setup
 
-If you want to use our [texer container](https://hub.docker.com/repository/docker/uavcan/texer) with vscode then install the ["ms-vscode-remote.vscode-remote-extensionpack"](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) and Docker. When you open vscode in this repostory it should prompt you to "open this folder in container?". Otherwise `F1` or `CMD+SHIFT+P` and select `Remote-Containers: Reopen Locally`. Once within the container you can simply `F1` or `CMD+SHIFT+P` and `LaTeX Workshop: Build LaTeX project` to build the specification PDF.
+If you want to use our [texer container](https://hub.docker.com/repository/docker/uavcan/texer) with vscode then install the ["ms-vscode-remote.vscode-remote-extensionpack"](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) and Docker. When you open vscode in this repository it should prompt you to "open this folder in container?". Otherwise `F1` or `CMD+SHIFT+P` and select `Remote-Containers: Reopen Locally`. Once within the container you can simply `F1` or `CMD+SHIFT+P` and `LaTeX Workshop: Build LaTeX project` to build the specification PDF.
 
 The above [may not work](https://github.com/microsoft/vscode-remote-release/issues/1097) if you are running an OSS build of VSCode (e.g., from Arch AUR). It is recommended to use the official binaries from Micro$oft.

--- a/README.md
+++ b/README.md
@@ -110,11 +110,7 @@ When done, run `./compile.sh`.
 #### Using texer
 
 You can use our Docker container to build the specification if you don't want to setup your own build environment.
-
-1. pull [texer container](https://hub.docker.com/r/uavcan/texer)
-2. `docker run --rm -it -v ${PWD}:/repo:delegated uavcan/texer:ubuntu-16.04`
-3. `pip3 install pydsdl`
-4. `./compile.sh`
+Build `.devcontainer/Dockerfile` and run `./compile.sh` inside the container.
 
 ### IDE setup
 

--- a/clean.sh
+++ b/clean.sh
@@ -2,14 +2,5 @@
 
 cd specification
 
-rm -f *.aux
-rm -f *.lof
-rm -f *.lot
-rm -f *.out
-rm -f *.toc
-rm -f *.log
-rm -f *.gz
-rm -f *-converted-to.*
-rm -f *.cache
-
+rm -f *.aux *.lof *.lot *.out *.toc *.log *.tmp *.gz *.cache *-converted-to.*
 rm -rf _minted-*

--- a/specification/.gitignore
+++ b/specification/.gitignore
@@ -30,9 +30,7 @@
 
 ## Build tool auxiliary files:
 *.fdb_latexmk
-*.synctex
-*.synctex.gz
-*.synctex.gz(busy)
+*.synctex*
 *.pdfsync
 
 ## Auxiliary and intermediate files from other packages:

--- a/specification/UAVCAN_Specification.tex
+++ b/specification/UAVCAN_Specification.tex
@@ -37,7 +37,7 @@
     \mbox{\texttt{\detokenize{#1}}} (section~\ref{sec:dsdl:#1} on page~\pageref{sec:dsdl:#1})%
 }
 
-\title{Specification v1.0-alpha}
+\title{Specification v1.0-beta}
 
 \hbadness=10000
 

--- a/specification/UAVCAN_Specification.tex
+++ b/specification/UAVCAN_Specification.tex
@@ -11,7 +11,6 @@
 \usepackage{amssymb}
 \usepackage{amsfonts}
 \usepackage{longtable}
-\usepackage{fontawesome}
 \usepackage{diagbox}
 
 \urlstyle{same}

--- a/specification/application/functions.tex
+++ b/specification/application/functions.tex
@@ -131,11 +131,7 @@ reliance on any particular vendor-specific data types.
 
 The namespace \DSDLReference{uavcan.si.unit} contains basic units that can be used as type-safe wrappers
 over \verb|float32| and other scalar and array types.
-
-The namespace \DSDLReference{uavcan.si.sample} contains time-stamped versions of the above,
-where the timestamp field is always located at the end in order to make the time-stamped types
-structural sub-types of the non-timestamped ones.
-The structural sub-typing enhances interoperability.
+The namespace \DSDLReference{uavcan.si.sample} contains time-stamped versions of the same.
 
 Each message type defined in the namespace \verb|uavcan.si.sample| contains a timestamp field of type
 \DSDLReference{uavcan.time.SynchronizedTimestamp}.

--- a/specification/basic/basic.tex
+++ b/specification/basic/basic.tex
@@ -66,12 +66,11 @@ but not more than one fixed port identifier.
 
 \subsubsection{Data type definitions}
 
-Message and service data types
+Message and service types
 are defined using the \emph{data structure description language} (DSDL) (chapter~\ref{sec:dsdl}).
-A DSDL definition specifies the name, major version, minor version, the data schemas,
+A DSDL definition specifies the name, major version, minor version, attributes,
 and an optional fixed port-ID of the data type among other less important properties.
-Message data types always define exactly one data schema, whereas
-service data types contain two independent schema definitions: one for request, and the other for response.
+Service types define two inferior data types: one for request, and the other for response.
 
 \subsubsection{Regulation}\label{sec:basic_data_type_regulation}
 

--- a/specification/basic/basic.tex
+++ b/specification/basic/basic.tex
@@ -70,7 +70,7 @@ Message and service types
 are defined using the \emph{data structure description language} (DSDL) (chapter~\ref{sec:dsdl}).
 A DSDL definition specifies the name, major version, minor version, attributes,
 and an optional fixed port-ID of the data type among other less important properties.
-Service types define two inferior data types: one for request, and the other for response.
+Service types define two inner data types: one for request, and the other for response.
 
 \subsubsection{Regulation}\label{sec:basic_data_type_regulation}
 

--- a/specification/dsdl/architecture.tex
+++ b/specification/dsdl/architecture.tex
@@ -6,7 +6,7 @@ In accordance with the UAVCAN architecture, DSDL allows users to define data typ
 message types and service types.
 Message types are used to exchange data over publish-subscribe one-to-many message links identified by subject-ID,
 and service types are used to perform request-response one-to-one exchanges (like RPC) identified by service-ID.
-A service type is composed of exactly two unutterable types:
+A service type is composed of exactly two unutterable inferior data types:
 one of them is the request type (its instances are transferred from client to server),
 and the other is the response type (its instances are transferred from the server back to the client).
 
@@ -93,7 +93,7 @@ A name component shall not match any of the reserved word patterns,
 which are listed in table~\ref{table:dsdl_reserved_word_patterns}.
 
 The length of a full data type name shall not exceed 50
-characters\footnote{This includes the name component separators.}.
+characters\footnote{This includes the name component separators, but not the version.}.
 
 Every data type definition is assigned a major and minor version number pair.
 In order to uniquely identify a data type definition, its version numbers shall be specified.
@@ -228,11 +228,17 @@ such as deprecation markers (notifying its users that the data type is no longer
 or assertions (special statements introduced by data type designers
 which are statically validated by DSDL processing tools).
 
-A service type definition is a special case: it can be neither a structure nor a tagged union,
-and it does not contain attributes;
-instead, it directly describes two inferior data types:
-the request type and the response type, separated by the \emph{service response marker},
-which are otherwise ordinary data types.
+Service type definitions are a special case:
+they cannot be instantiated or serialized, they do not contain attributes,
+and they are composed of exactly two inferior data type definitions\footnote{
+    A service type can be thought of as a specialized namespace that contains two types and
+    has some of the properties of a type, such as name and version.
+}.
+These inferior types are the service request type and the service response type,
+separated by the \emph{service response marker}.
+The inferiors are otherwise ordinary data types except that they are unutterable\footnote{Cannot be referred to.}
+and they derive some of their properties\footnote{Like version numbers or deprecation status.}
+from their \emph{parent service type}.
 
 \subsection{Serialization}
 
@@ -256,4 +262,5 @@ which is attached to the serialized object, along with other metadata, in a mann
 transport layer specification (chapter~\ref{sec:transport}).
 For more information on port identifiers and data type mapping refer to section~\ref{sec:basic_subjects_and_services}.
 
-The bit length set is not defined on service types (only on their inferiors: request and response).
+The bit length set is not defined on service types (only on their inferiors: request and response)
+because they cannot be instantiated.

--- a/specification/dsdl/architecture.tex
+++ b/specification/dsdl/architecture.tex
@@ -6,7 +6,7 @@ In accordance with the UAVCAN architecture, DSDL allows users to define data typ
 message types and service types.
 Message types are used to exchange data over publish-subscribe one-to-many message links identified by subject-ID,
 and service types are used to perform request-response one-to-one exchanges (like RPC) identified by service-ID.
-A service type is composed of exactly two unutterable inferior data types:
+A service type is composed of exactly two inner data types:
 one of them is the request type (its instances are transferred from client to server),
 and the other is the response type (its instances are transferred from the server back to the client).
 
@@ -230,13 +230,13 @@ which are statically validated by DSDL processing tools).
 
 Service type definitions are a special case:
 they cannot be instantiated or serialized, they do not contain attributes,
-and they are composed of exactly two inferior data type definitions\footnote{
+and they are composed of exactly two inner data type definitions\footnote{
     A service type can be thought of as a specialized namespace that contains two types and
     has some of the properties of a type, such as name and version.
 }.
-These inferior types are the service request type and the service response type,
+These inner types are the service request type and the service response type,
 separated by the \emph{service response marker}.
-The inferiors are otherwise ordinary data types except that they are unutterable\footnote{Cannot be referred to.}
+They are otherwise ordinary data types except that they are unutterable\footnote{Cannot be referred to.}
 and they derive some of their properties\footnote{Like version numbers or deprecation status.}
 from their \emph{parent service type}.
 
@@ -262,5 +262,5 @@ which is attached to the serialized object, along with other metadata, in a mann
 transport layer specification (chapter~\ref{sec:transport}).
 For more information on port identifiers and data type mapping refer to section~\ref{sec:basic_subjects_and_services}.
 
-The bit length set is not defined on service types (only on their inferiors: request and response)
+The bit length set is not defined on service types (only on their request and response types)
 because they cannot be instantiated.

--- a/specification/dsdl/architecture.tex
+++ b/specification/dsdl/architecture.tex
@@ -6,10 +6,9 @@ In accordance with the UAVCAN architecture, DSDL allows users to define data typ
 message types and service types.
 Message types are used to exchange data over publish-subscribe one-to-many message links identified by subject-ID,
 and service types are used to perform request-response one-to-one exchanges (like RPC) identified by service-ID.
-A message data type defines one data schema of the message object,
-and a service data type contains two independent data schema definitions:
-one of them applies to the request object (transferred from client to server),
-and the other applies to the response object (transferred from the server back to the client).
+A service type is composed of exactly two unutterable types:
+one of them is the request type (its instances are transferred from client to server),
+and the other is the response type (its instances are transferred from the server back to the client).
 
 Following the deterministic nature of UAVCAN, the size of a serialized representation of any
 message or service object is bounded within statically known limits.
@@ -194,16 +193,15 @@ nesting\footnote{%
     \end{figure}
 \end{remark}
 
-\subsection{Elements of data type definition}
+\subsection{Elements of data type definition}\label{sec:dsdl_elements_of_data_type_definition}
 
 A data type definition file contains an exhaustive description of a particular version of the said data type in the
 \emph{data structure description language} (DSDL).
-As explained above, one data type definition contains either one or two data schema definitions,
-for message types and service types, respectively.
 
-A data schema definition contains an ordered, possibly empty collection of \emph{field attributes} and/or
+A data type definition contains an ordered, possibly empty collection of \emph{field attributes} and/or
 unordered, possibly empty collection of \emph{constant attributes}.
-A data schema may describe either a \emph{structure object} or a \emph{tagged union object}.
+
+A data type may describe either a \emph{structure object} or a \emph{tagged union object}.
 The value of a structure object is a function of the values of all of its field attributes.
 A tagged union object is formed from at least two field attributes,
 but it is capable of holding exactly one field attribute value at any given time.
@@ -230,6 +228,12 @@ such as deprecation markers (notifying its users that the data type is no longer
 or assertions (special statements introduced by data type designers
 which are statically validated by DSDL processing tools).
 
+A service type definition is a special case: it can be neither a structure nor a tagged union,
+and it does not contain attributes;
+instead, it directly describes two inferior data types:
+the request type and the response type, separated by the \emph{service response marker},
+which are otherwise ordinary data types.
+
 \subsection{Serialization}
 
 Every object that can be exchanged between UAVCAN nodes has a well-defined \emph{serialized representation}.
@@ -240,10 +244,10 @@ Such recovery process is called \emph{deserialization}.
 \label{sec:dsdl_bit_length_set}
 A serialized representation is a sequence of binary digits (bits);
 the number of bits in a serialized representation is called its \emph{bit length}.
-A \emph{bit length set} of a data type (or a data schema) refers to the set of bit length values of all possible
-serialized representations of objects that are instances of the data type (or that follow the data schema).
+A \emph{bit length set} of a data type refers to the set of bit length values of all possible
+serialized representations of objects that are instances of the data type.
 
-A data type or schema whose bit length set contains more than one element is said to be \emph{variable length}.
+A data type whose bit length set contains more than one element is said to be \emph{variable length}.
 The opposite case is referred to as \emph{fixed length}.
 
 The data type of a serialized message or service object exchanged over the network
@@ -251,3 +255,5 @@ is recovered from its subject-ID or service-ID, respectively,
 which is attached to the serialized object, along with other metadata, in a manner dictated by the applicable
 transport layer specification (chapter~\ref{sec:transport}).
 For more information on port identifiers and data type mapping refer to section~\ref{sec:basic_subjects_and_services}.
+
+The bit length set is not defined on service types (only on their inferiors: request and response).

--- a/specification/dsdl/architecture.tex
+++ b/specification/dsdl/architecture.tex
@@ -236,7 +236,9 @@ and they are composed of exactly two inner data type definitions\footnote{
 }.
 These inner types are the service request type and the service response type,
 separated by the \emph{service response marker}.
-They are otherwise ordinary data types except that they are unutterable\footnote{Cannot be referred to.}
+They are otherwise ordinary data types except that they are unutterable\footnote{%
+    Cannot be referred to. Another commonly used term is ``Voldemort type''.
+}
 and they derive some of their properties\footnote{Like version numbers or deprecation status.}
 from their \emph{parent service type}.
 

--- a/specification/dsdl/attributes.tex
+++ b/specification/dsdl/attributes.tex
@@ -156,29 +156,17 @@ and the category of the containing data schema definition.
 If the current data schema definition belongs to the tagged union category,
 the referring statement shall be located after the last field attribute definition.
 A field attribute definition following the referring statement renders the current definition invalid.
-For tagged unions, the value of the offset attribute is defined as:
-$$
-    \texttt{\_offset\_}_\text{union} =
-    \bigcup\limits_{i=1}^{n}
-    \left\{ 2^{\lceil\log_2 \text{max}\left(8, \lceil\log_2 n\rceil\right)\rceil} + b : b \in B_i \right\}
-$$
-where $n$ is the number of fields defined in the current union definition,
-and $B_i$ is the bit length set of the data type of the field number $i$.
+For tagged unions, the value of the offset attribute is defined as the
+cumulative bit length set\footnote{Section \ref{sec:dsdl_composite_alignment_cumulative_bls}.}
+of the union's fields, where each element of the set is incremented by the bit length of the implicit union tag field
+(section \ref{sec:dsdl_serialization_composite}).
 
 If the current data schema definition does not belong to the tagged union category,
 the referring statement may be located anywhere within the current data schema definition.
-The value of the offset attribute is defined as:
-$$
-    \texttt{\_offset\_} =
-    \begin{cases}
-        \left\{ \sum s : s \in \prod\limits_{i=1}^{n} B_i \right\} &\mid n > 0 \\
-        \left\{0\right\}                                           &\mid n = 0 \\
-    \end{cases}
-$$
-where $n$ is the number of fields defined in statements preceding the referring statement
-(see section~\ref{sec:dsdl_grammar} on statement ordering),
-$B_i$ is the bit length set of the data type of the field number $i$,
-and $\prod$ is the Cartesian product operator.
+The value of the offset attribute is defined as the
+cumulative bit length set\footnote{Section \ref{sec:dsdl_composite_alignment_cumulative_bls}.}
+of the fields defined in statements preceding the referring statement
+(see section~\ref{sec:dsdl_grammar} on statement ordering).
 
 \begin{remark}
     \begin{minted}{python}
@@ -206,4 +194,3 @@ and $\prod$ is the Cartesian product operator.
         uint8 well_aligned   # Proven to be byte-aligned.
     \end{minted}
 \end{remark}
-

--- a/specification/dsdl/attributes.tex
+++ b/specification/dsdl/attributes.tex
@@ -9,7 +9,7 @@ A composite type attribute that has a value assigned at the data type definition
 a composite type attribute that does not have a value assigned at the definition time is called a
 \emph{field attribute}.
 
-The name of a composite type attribute shall be unique within its data schema definition
+The name of a composite type attribute shall be unique within the data type definition that contains it,
 and it shall not match any of the reserved name patterns specified in the table
 \ref{table:dsdl_reserved_word_patterns}.
 This requirement does not apply to padding fields.
@@ -103,7 +103,11 @@ a DSDL definition is an ordered collection of statements;
 a statement may contain DSDL expressions.
 An expression contained in a statement number $E$ may refer to a
 composite type attribute introduced in a statement number $A$ by its name,
-where $A < E$ and both statements belong to the same data schema definition.
+where $A < E$ and both statements belong to the same data type definition\footnote{
+    Per \ref{sec:dsdl_elements_of_data_type_definition},
+    in case of service types, this applies only to their request and response inferiors.
+    Service types themselves cannot contain attributes.
+}.
 The representation of the referred attribute in the context of the referring DSDL expression
 is specified in table~\ref{table:dsdl_local_attribute_representation}.
 
@@ -128,7 +132,7 @@ is specified in table~\ref{table:dsdl_local_attribute_representation}.
         uint8 FOO = 123
         uint16 BAR = FOO ** 2
         @assert BAR == 15129
-        ---  # The request data schema definition ends here; its attributes are no longer accessible.
+        ---  # The request type ends here; its attributes are no longer accessible.
         #uint16 BAZ = BAR  # Would fail - BAR is not accessible here.
         float64 FOO = 3.14
         @assert FOO == 3.14
@@ -151,9 +155,9 @@ containing an expression which refers to the offset attribute.
 The term \emph{bit length set} is defined in section~\ref{sec:dsdl_bit_length_set}.
 
 The value of the attribute is a function of the field attribute declarations preceding the referring statement
-and the category of the containing data schema definition.
+and the category of the containing definition.
 
-If the current data schema definition belongs to the tagged union category,
+If the current definition belongs to the tagged union category,
 the referring statement shall be located after the last field attribute definition.
 A field attribute definition following the referring statement renders the current definition invalid.
 For tagged unions, the value of the offset attribute is defined as the
@@ -161,8 +165,8 @@ cumulative bit length set\footnote{Section \ref{sec:dsdl_composite_alignment_cum
 of the union's fields, where each element of the set is incremented by the bit length of the implicit union tag field
 (section \ref{sec:dsdl_serialization_composite}).
 
-If the current data schema definition does not belong to the tagged union category,
-the referring statement may be located anywhere within the current data schema definition.
+If the current data definition does not belong to the tagged union category,
+the referring statement may be located anywhere within the current definition.
 The value of the offset attribute is defined as the
 cumulative bit length set\footnote{Section \ref{sec:dsdl_composite_alignment_cumulative_bls}.}
 of the fields defined in statements preceding the referring statement

--- a/specification/dsdl/attributes.tex
+++ b/specification/dsdl/attributes.tex
@@ -105,8 +105,7 @@ An expression contained in a statement number $E$ may refer to a
 composite type attribute introduced in a statement number $A$ by its name,
 where $A < E$ and both statements belong to the same data type definition\footnote{
     Per \ref{sec:dsdl_elements_of_data_type_definition},
-    in case of service types, this applies only to their request and response inferiors.
-    Service types themselves cannot contain attributes.
+    in case of services, this applies only to their request and response types.
 }.
 The representation of the referred attribute in the context of the referring DSDL expression
 is specified in table~\ref{table:dsdl_local_attribute_representation}.

--- a/specification/dsdl/compatibility.tex
+++ b/specification/dsdl/compatibility.tex
@@ -105,7 +105,7 @@ the version numbers of its first definition shall be assigned ``1.0'' (major 1, 
 
 In order to ensure predictability and functional safety of applications that leverage UAVCAN,
 it is required that once a data type definition is released,
-its DSDL source text, name, version numbers, fixed port-ID, and other properties cannot undergo any
+its DSDL source text, name, version numbers, fixed port-ID, extent, finality, and other properties cannot undergo any
 modifications whatsoever, with the following exceptions:
 \begin{itemize}
     \item Whitespace changes of the DSDL source text are allowed,
@@ -142,6 +142,8 @@ per combination of data type name and version number pair.
 All data types under the same name shall be also of the same kind.
 In other words, if the first released definition of a data type is of the message kind,
 all other versions shall also be of the message kind.
+
+All data types under the same name and major version number should share the same extent and the same finality status.
 
 \subsubsection{Fixed port identifier assignment constraints}
 

--- a/specification/dsdl/compatibility.tex
+++ b/specification/dsdl/compatibility.tex
@@ -144,6 +144,16 @@ In other words, if the first released definition of a data type is of the messag
 all other versions shall also be of the message kind.
 
 All data types under the same name and major version number should share the same extent and the same finality status.
+It is therefore advised to:
+\begin{itemize}
+    \item Avoid marking types final, especially complex types,
+    because it is likely to render their evolution impossible.
+
+    \item When the first version is released, its extent should be sufficiently large
+    to permit addition of new fields in the future.
+    Since the value of extent does not affect the network traffic, it is safe to pick a large value
+    without compromising the temporal properties of the system.
+\end{itemize}
 
 \subsubsection{Fixed port identifier assignment constraints}
 
@@ -296,7 +306,9 @@ The minor versions may differ, which is acceptable due to the major version comp
 
     Imagine that later it was determined that the module should report additional status information
     relating to the coolant pump.
-    Thanks to the implicit truncation and the implicit zero extension rules,
+    Thanks to the implicit truncation (section \ref{sec:dsdl_serialization_implicit_truncation}),
+    implicit zero extension (section \ref{sec:dsdl_serialization_implicit_zero_extension}),
+    and the delimited serialization (section \ref{sec:dsdl_serialization_composite_non_final}),
     the new fields can be introduced in a semantically-compatible way without releasing
     a new major version of the data type:
 
@@ -319,6 +331,8 @@ The minor versions may differ, which is acceptable due to the major version comp
         float32 volumetric_flow_rate    # [meter^3/second]
         # Coolant pump fields (extension over v2.0; implicit truncation/extension rules apply)
         # If zero, assume that the values are unavailable.
+
+        @extent 32*8  # Set the extent manually so that it is the same as in the previous version v2.0.
     \end{minted}
 
     It is also possible to add an optional field at the end wrapped into a variable-length

--- a/specification/dsdl/compatibility.tex
+++ b/specification/dsdl/compatibility.tex
@@ -105,7 +105,7 @@ the version numbers of its first definition shall be assigned ``1.0'' (major 1, 
 
 In order to ensure predictability and functional safety of applications that leverage UAVCAN,
 it is required that once a data type definition is released,
-its DSDL source text, name, version numbers, fixed port-ID, extent, finality, and other properties cannot undergo any
+its DSDL source text, name, version numbers, fixed port-ID, extent, sealing, and other properties cannot undergo any
 modifications whatsoever, with the following exceptions:
 \begin{itemize}
     \item Whitespace changes of the DSDL source text are allowed,
@@ -143,10 +143,10 @@ All data types under the same name shall be also of the same kind.
 In other words, if the first released definition of a data type is of the message kind,
 all other versions shall also be of the message kind.
 
-All data types under the same name and major version number should share the same extent and the same finality status.
+All data types under the same name and major version number should share the same extent and the same sealing status.
 It is therefore advised to:
 \begin{itemize}
-    \item Avoid marking types final, especially complex types,
+    \item Avoid marking types sealed, especially complex types,
     because it is likely to render their evolution impossible.
 
     \item When the first version is released, its extent should be sufficiently large
@@ -308,7 +308,7 @@ The minor versions may differ, which is acceptable due to the major version comp
     relating to the coolant pump.
     Thanks to the implicit truncation (section \ref{sec:dsdl_serialization_implicit_truncation}),
     implicit zero extension (section \ref{sec:dsdl_serialization_implicit_zero_extension}),
-    and the delimited serialization (section \ref{sec:dsdl_serialization_composite_non_final}),
+    and the delimited serialization (section \ref{sec:dsdl_serialization_composite_non_sealed}),
     the new fields can be introduced in a semantically-compatible way without releasing
     a new major version of the data type:
 

--- a/specification/dsdl/compatibility.tex
+++ b/specification/dsdl/compatibility.tex
@@ -155,6 +155,14 @@ It is therefore advised to:
     without compromising the temporal properties of the system.
 \end{itemize}
 
+\begin{remark}
+    Suppose that there is a new data type v1.0.
+    Then, v1.1 is released whose bit length set is different (for example, a field was added or removed).
+    To keep the extent compatible with v1.0,
+    the author of v1.1 should now set it explicitly using the \verb|@extent| directive.
+    It may be preferred to set the extent manually starting with v1.0 for clarity.
+\end{remark}
+
 \subsubsection{Fixed port identifier assignment constraints}
 
 The following constraints apply to fixed port-ID assignments:

--- a/specification/dsdl/conventions.tex
+++ b/specification/dsdl/conventions.tex
@@ -66,7 +66,7 @@ even if not populated, and special case values undermine type safety.
     Union-based optional field:
 
     \begin{minted}{python}
-        @final                          # Sic!
+        @sealed                         # Sic!
         @union                          # The implicit tag is one byte long.
         uavcan.primitive.Empty none     # Represents lack of value, unpopulated field.
         MyType some                     # The field of interest; field ordering is important.

--- a/specification/dsdl/conventions.tex
+++ b/specification/dsdl/conventions.tex
@@ -60,12 +60,14 @@ even if not populated, and special case values undermine type safety.
     Array-based optional field:
 
     \begin{minted}{python}
+        @final
         MyType[<=1] optional_field
     \end{minted}
 
     Union-based optional field:
 
     \begin{minted}{python}
+        @final
         @union                          # The implicit tag is one byte long.
         uavcan.primitive.Empty none     # Represents lack of value, unpopulated field.
         MyType some                     # The field of interest; field ordering is important.
@@ -107,6 +109,7 @@ even if not populated, and special case values undermine type safety.
     and another node is receiving it using the new definition.
     The implicit zero extension rule guarantees that the optional field array will
     appear empty to the receiving node because the implicit length field will be read as zero.
+    Same is true if the message was nested inside another one, thanks to the delimiter header.
 \end{remark}
 
 \subsection{Bit flag representation}

--- a/specification/dsdl/conventions.tex
+++ b/specification/dsdl/conventions.tex
@@ -60,14 +60,13 @@ even if not populated, and special case values undermine type safety.
     Array-based optional field:
 
     \begin{minted}{python}
-        @final
         MyType[<=1] optional_field
     \end{minted}
 
     Union-based optional field:
 
     \begin{minted}{python}
-        @final
+        @final                          # Sic!
         @union                          # The implicit tag is one byte long.
         uavcan.primitive.Empty none     # Represents lack of value, unpopulated field.
         MyType some                     # The field of interest; field ordering is important.

--- a/specification/dsdl/directives.tex
+++ b/specification/dsdl/directives.tex
@@ -7,17 +7,21 @@ In this section, it is assumed that a directive does not expect an expression un
 If the expectation of an associated directive expression or lack thereof is violated,
 the containing DSDL definition is malformed.
 
+The effect of a directive is confined to the data type definition that contains it.
+That means that for service types, a directive only affects its inferior,
+unless specifically stated otherwise.
+
 \subsection{Tagged union marker}
 
 The identifier of the tagged union marker directive is ``\verb|union|''.
 Presence of this directive in a data type definition indicates that the
-data schema definition containing this directive belongs to the tagged union category
+data type definition containing this directive belongs to the tagged union category
 (section~\ref{sec:dsdl_composite_tagged_unions}).
 
 Usage of this directive is subject to the following constraints:
 \begin{itemize}
-    \item The directive shall not be used more than once per data schema definition.
-    \item The directive shall be placed before the first composite type attribute definition in the current data schema.
+    \item The directive shall not be used more than once per data type definition.
+    \item The directive shall be placed before the first composite type attribute definition in the current definition.
 \end{itemize}
 
 \begin{remark}
@@ -34,20 +38,20 @@ Usage of this directive is subject to the following constraints:
 \subsection{Explicit extent specifier}\label{sec:dsdl_directive_extent}
 
 The identifier of the explicit extent specification directive is ``\verb|extent|''.
-This directive overrides the default extent of its schema (section \ref{sec:dsdl_composite_extent_and_finality})
+This directive overrides the default extent of its data type (section \ref{sec:dsdl_composite_extent_and_finality})
 with the value obtained by evaluating the provided expression.
 The expression shall be present and it shall yield a non-negative integer value of type
 ``\verb|rational|'' (section~\ref{sec:dsdl_primitive_types}) upon its evaluation.
 
 Usage of this directive is subject to the following constraints (otherwise, the definition is malformed):
 \begin{itemize}
-    \item The directive shall not be used more than once per data schema definition.
-    \item The directive shall be placed after the last attribute definition in the current data schema\footnote{%
+    \item The directive shall not be used more than once per data type definition.
+    \item The directive shall be placed after the last attribute definition in the current data type\footnote{%
               This constraint is to help avoid issues where the extent is defined as a function of the offset past
-              the last field of the schema, and a new field is mistakenly added after the extent directive.
+              the last field of the type, and a new field is mistakenly added after the extent directive.
           }.
     \item The value shall satisfy the constraints given in section \ref{sec:dsdl_composite_extent_and_finality}.
-    \item The schema shall not be final.
+    \item The data type shall not be final.
 \end{itemize}
 
 \begin{remark}
@@ -68,22 +72,22 @@ Usage of this directive is subject to the following constraints (otherwise, the 
 \subsection{Finality marker}\label{sec:dsdl_directive_final}
 
 The identifier of the finality marker directive is ``\verb|final|''.
-This directive marks the current schema final (section \ref{sec:dsdl_composite_extent_and_finality})
-(if not provided, the schema is non-final).
+This directive marks the current data type final (section \ref{sec:dsdl_composite_extent_and_finality})
+(if not provided, the data type is non-final).
 
 Usage of this directive is subject to the following constraints (otherwise, the definition is malformed):
 \begin{itemize}
-    \item The directive shall not be used more than once per data schema definition.
-    \item The extent directive shall not be used in this data schema definition.
+    \item The directive shall not be used more than once per data type definition.
+    \item The extent directive shall not be used in this data type definition.
 \end{itemize}
 
 \begin{remark}
     \begin{minted}{python}
         uint64 foo
-        @final        # The request schema is final.
-        #@extent 128  # Would fail -- cannot specify extent for final schema
+        @final        # The request type is final.
+        #@extent 128  # Would fail -- cannot specify extent for final type
         ---
-        float64 bar   # The response schema is not final.
+        float64 bar   # The response type is not final.
         @extent 4000 * 8
     \end{minted}
 \end{remark}
@@ -101,8 +105,9 @@ in the generated code.
 Usage of this directive is subject to the following constraints:
 \begin{itemize}
     \item The directive shall not be used more than once per data type definition.
-    \item The directive shall be placed before the first composite type attribute definition in
-          the first data schema definition.
+    \item The directive shall be placed before the first composite type attribute definition in the definition.
+    \item In case of service types, this directive may only be placed in the request inferior,
+    and it affects the response inferior as well.
 \end{itemize}
 
 \begin{remark}
@@ -111,7 +116,7 @@ Usage of this directive is subject to the following constraints:
         uint8 FOO = 123
         #@deprecated        # Would fail - shall be placed before the first attribute definition
         ---
-        #@deprecated        # Would fail - shall be placed in the first data schema definition
+        #@deprecated        # Would fail - shall be placed in the request inferior
     \end{minted}
 
     A C++ class generated from the above definition could be annotated with the \verb|[[deprecated]]| attribute.

--- a/specification/dsdl/directives.tex
+++ b/specification/dsdl/directives.tex
@@ -8,8 +8,8 @@ If the expectation of an associated directive expression or lack thereof is viol
 the containing DSDL definition is malformed.
 
 The effect of a directive is confined to the data type definition that contains it.
-That means that for service types, a directive only affects its inferior,
-unless specifically stated otherwise.
+That means that for service types, unless specifically stated otherwise,
+a directive placed in the request (response) type affects only the request (response) type.
 
 \subsection{Tagged union marker}
 
@@ -69,7 +69,7 @@ Usage of this directive is subject to the following constraints (otherwise, the 
     \end{minted}
 \end{remark}
 
-\subsection{Sealing marker}\label{sec:dsdl_directive_sealing}
+\subsection{Sealing marker}\label{sec:dsdl_directive_sealed}
 
 The identifier of the sealing marker directive is ``\verb|sealed|''.
 This directive marks the current data type sealed (section \ref{sec:dsdl_composite_extent_and_sealing})
@@ -106,8 +106,8 @@ Usage of this directive is subject to the following constraints:
 \begin{itemize}
     \item The directive shall not be used more than once per data type definition.
     \item The directive shall be placed before the first composite type attribute definition in the definition.
-    \item In case of service types, this directive may only be placed in the request inferior,
-    and it affects the response inferior as well.
+    \item In case of service types, this directive may only be placed in the request type,
+    and it affects the response type as well.
 \end{itemize}
 
 \begin{remark}
@@ -116,7 +116,7 @@ Usage of this directive is subject to the following constraints:
         uint8 FOO = 123
         #@deprecated        # Would fail - shall be placed before the first attribute definition
         ---
-        #@deprecated        # Would fail - shall be placed in the request inferior
+        #@deprecated        # Would fail - shall be placed in the request type
     \end{minted}
 
     A C++ class generated from the above definition could be annotated with the \verb|[[deprecated]]| attribute.

--- a/specification/dsdl/directives.tex
+++ b/specification/dsdl/directives.tex
@@ -38,7 +38,7 @@ Usage of this directive is subject to the following constraints:
 \subsection{Explicit extent specifier}\label{sec:dsdl_directive_extent}
 
 The identifier of the explicit extent specification directive is ``\verb|extent|''.
-This directive overrides the default extent of its data type (section \ref{sec:dsdl_composite_extent_and_finality})
+This directive overrides the default extent of its data type (section \ref{sec:dsdl_composite_extent_and_sealing})
 with the value obtained by evaluating the provided expression.
 The expression shall be present and it shall yield a non-negative integer value of type
 ``\verb|rational|'' (section~\ref{sec:dsdl_primitive_types}) upon its evaluation.
@@ -50,15 +50,15 @@ Usage of this directive is subject to the following constraints (otherwise, the 
               This constraint is to help avoid issues where the extent is defined as a function of the offset past
               the last field of the type, and a new field is mistakenly added after the extent directive.
           }.
-    \item The value shall satisfy the constraints given in section \ref{sec:dsdl_composite_extent_and_finality}.
-    \item The data type shall not be final.
+    \item The value shall satisfy the constraints given in section \ref{sec:dsdl_composite_extent_and_sealing}.
+    \item The data type shall not be sealed.
 \end{itemize}
 
 \begin{remark}
     \begin{minted}{python}
         uint64 foo
         @extent 256 * 8  # Make the extent 256 bytes large
-        #@final          # Would fail -- mutually exclusive directives
+        #@sealed         # Would fail -- mutually exclusive directives
     \end{minted}
 
     \begin{minted}{python}
@@ -69,11 +69,11 @@ Usage of this directive is subject to the following constraints (otherwise, the 
     \end{minted}
 \end{remark}
 
-\subsection{Finality marker}\label{sec:dsdl_directive_final}
+\subsection{Sealing marker}\label{sec:dsdl_directive_sealing}
 
-The identifier of the finality marker directive is ``\verb|final|''.
-This directive marks the current data type final (section \ref{sec:dsdl_composite_extent_and_finality})
-(if not provided, the data type is non-final).
+The identifier of the sealing marker directive is ``\verb|sealed|''.
+This directive marks the current data type sealed (section \ref{sec:dsdl_composite_extent_and_sealing})
+(if not provided, the data type is non-sealed).
 
 Usage of this directive is subject to the following constraints (otherwise, the definition is malformed):
 \begin{itemize}
@@ -84,10 +84,10 @@ Usage of this directive is subject to the following constraints (otherwise, the 
 \begin{remark}
     \begin{minted}{python}
         uint64 foo
-        @final        # The request type is final.
-        #@extent 128  # Would fail -- cannot specify extent for final type
+        @sealed       # The request type is sealed.
+        #@extent 128  # Would fail -- cannot specify extent for sealed type
         ---
-        float64 bar   # The response type is not final.
+        float64 bar   # The response type is not sealed.
         @extent 4000 * 8
     \end{minted}
 \end{remark}

--- a/specification/dsdl/directives.tex
+++ b/specification/dsdl/directives.tex
@@ -31,6 +31,63 @@ Usage of this directive is subject to the following constraints:
     \end{minted}
 \end{remark}
 
+\subsection{Explicit extent specifier}\label{sec:dsdl_directive_extent}
+
+The identifier of the explicit extent specification directive is ``\verb|extent|''.
+This directive overrides the default extent of its schema (section \ref{sec:dsdl_composite_extent_and_finality})
+with the value obtained by evaluating the provided expression.
+The expression shall be present and it shall yield a non-negative integer value of type
+``\verb|rational|'' (section~\ref{sec:dsdl_primitive_types}) upon its evaluation.
+
+Usage of this directive is subject to the following constraints (otherwise, the definition is malformed):
+\begin{itemize}
+    \item The directive shall not be used more than once per data schema definition.
+    \item The directive shall be placed after the last attribute definition in the current data schema\footnote{%
+              This constraint is to help avoid issues where the extent is defined as a function of the offset past
+              the last field of the schema, and a new field is mistakenly added after the extent directive.
+          }.
+    \item The value shall satisfy the constraints given in section \ref{sec:dsdl_composite_extent_and_finality}.
+    \item The schema shall not be final.
+\end{itemize}
+
+\begin{remark}
+    \begin{minted}{python}
+        uint64 foo
+        @extent 256 * 8  # Make the extent 256 bytes large
+        #@final          # Would fail -- mutually exclusive directives
+    \end{minted}
+
+    \begin{minted}{python}
+        uint64[<=64] bar
+        @extent _offset_.max * 2
+        #float32 baz  # Would fail (protects against incorrectly computing
+                      # the extent when it is a function of _offset_)
+    \end{minted}
+\end{remark}
+
+\subsection{Finality marker}\label{sec:dsdl_directive_final}
+
+The identifier of the finality marker directive is ``\verb|final|''.
+This directive marks the current schema final (section \ref{sec:dsdl_composite_extent_and_finality})
+(if not provided, the schema is non-final).
+
+Usage of this directive is subject to the following constraints (otherwise, the definition is malformed):
+\begin{itemize}
+    \item The directive shall not be used more than once per data schema definition.
+    \item The extent directive shall not be used in this data schema definition.
+\end{itemize}
+
+\begin{remark}
+    \begin{minted}{python}
+        uint64 foo
+        @final        # The request schema is final.
+        #@extent 128  # Would fail -- cannot specify extent for final schema
+        ---
+        float64 bar   # The response schema is not final.
+        @extent 4000 * 8
+    \end{minted}
+\end{remark}
+
 \subsection{Deprecation marker}
 
 The identifier of the deprecation marker directive is ``\verb|deprecated|''.
@@ -107,4 +164,3 @@ If the expression is provided but cannot be evaluated, the containing DSDL defin
         @print 'we all float64 down here\n'  # Possible output: 'we all float64 down here\n'
     \end{minted}
 \end{remark}
-

--- a/specification/dsdl/serializable_types.tex
+++ b/specification/dsdl/serializable_types.tex
@@ -7,7 +7,7 @@ This is opposed to the expression types (section~\ref{sec:dsdl_expression_types}
 instances of which can only exist while DSDL definitions are being evaluated.
 The data serialization rules are defined in section~\ref{sec:dsdl_data_serialization}.
 
-\subsubsection{Alignment and padding}
+\subsubsection{Alignment and padding}\label{sec:dsdl_serializable_alignment_padding}
 
 For any type, its \emph{alignment} $A$ is defined as some positive integer number of bits such that the offset of a
 serialized representation of an instance of this type relative to the origin of the
@@ -230,12 +230,6 @@ The alignment of an array equals the alignment of its element type\footnote{
 
 \subsection{Composite types}\label{sec:dsdl_composite_types}
 
-The alignment of composite types is one byte (8 bits)\footnote{%
-    Regardless of the content.
-    It follows that empty composites can be inserted arbitrarily to force byte alignment
-    of the next field(s) at runtime.
-}.
-
 \subsubsection{Kinds}
 
 There are two kinds of composite data type definitions: message types and service types.
@@ -320,7 +314,7 @@ The available attributes and their semantics are documented in the section~\ref{
     \end{minted}
 \end{remark}
 
-\subsubsection{Unions}\label{sec:dsdl_composite_tagged_unions}
+\subsubsection{Tagged unions}\label{sec:dsdl_composite_tagged_unions}
 
 Any data schema definition can be supplied with a special directive (section~\ref{sec:dsdl_directives})
 indicating that it forms a tagged union.
@@ -330,6 +324,28 @@ A tagged union shall not contain padding field attributes.
 
 The value of a tagged union object is a function of the field attribute which value it is currently holding
 and the value of the field attribute itself.
+
+To avoid ambiguity, a data schema that is not a tagged union is referred to as a \emph{structure}.
+
+\subsubsection{Alignment and cumulative bit length set}\label{sec:dsdl_composite_alignment_cumulative_bls}
+
+The alignment of composite types is one byte (8 bits)\footnote{%
+    Regardless of the content.
+    It follows that empty composites can be inserted arbitrarily to force byte alignment
+    of the next field(s) at runtime.
+}.
+
+Per the definitions given in \ref{sec:dsdl_serializable_alignment_padding},
+a serialized representation of a composite type is padded to 8 bits by inserting padding bits
+after its last element until the resulting length is a multiple of 8 bits.
+
+Given a set of field attributes, their \emph{cumulative bit length set} is computed
+by evaluating every permutation of their respective bit length sets plus the required padding.
+For tagged unions, this amounts to the union of the bit length sets of each field
+plus the bit length set of the implicit union tag prefix.
+Otherwise, the cumulative bit length set is the Cartesian product of the bit length sets of each field
+plus the required inter-field padding.
+The specifics are given in section \ref{sec:dsdl_data_serialization}.
 
 \subsubsection{Extent and finality}\label{sec:dsdl_composite_extent_and_finality}
 
@@ -384,10 +400,12 @@ The related mechanics are described in section \ref{sec:dsdl_data_serialization}
     \caption{Serialized representation and extent\label{fig:dsdl_extent}}
 \end{figure}
 
-The default extent of a non-final definition is the following function of its bit length set $B$:
+The default extent of a non-final definition is the following function
+of the cumulative bit length set\footnote{Section \ref{sec:dsdl_composite_alignment_cumulative_bls}.}
+of its fields $B$:
 
 $$
-\text{Ext}_\text{default}\left(B\right) =
+X_\text{default}\left(B\right) =
 \left\lceil{}\left\lfloor{}\frac{3}{2} \max{}\left(B\right)\right\rfloor{}/8\right\rceil{}8
 $$
 
@@ -402,6 +420,72 @@ unless the definition is final.
 
 By default, a definition is not final unless explicitly indicated otherwise using the directive described in
 section \ref{sec:dsdl_directive_final}.
+
+\subsubsection{Bit length set}
+
+The bit length set of a final composite type equals the cumulative bit length set
+of its fields plus the final padding (see section \ref{sec:dsdl_composite_alignment_cumulative_bls}).
+
+\begin{remark}
+    The bit length set of the following is $\left\{ 8, 24, 40, 56 \right\}$:
+    \begin{minted}{python}
+        uint16[<=3] foo
+        @final
+    \end{minted}
+
+    The bit length set of the following is $\left\{ 16, 32, 48, 64 \right\}$:
+    \begin{minted}{python}
+        uint16[<=3] foo
+        int2 bar
+        @final
+    \end{minted}
+
+    The bit length set of the following is $\left\{ 8, 16 \right\}$:
+    \begin{minted}{python}
+        bool[<=3] foo
+        @final
+    \end{minted}
+\end{remark}
+
+The bit length set of a non-final composite type is dependent only on its extent $X$, and is defined as follows:
+$$
+    \left\{ B_\text{DH} + 8b \mid b \in \mathbb{Z},\ 0 \leq b \leq \frac{X}{8} \right\}
+$$
+where $B_\text{DH}$ is the bit length of the \emph{delimiter header}
+as defined in section \ref{sec:dsdl_serialization_composite_non_final}.
+
+\begin{remark}
+    This is intentionally not dependent on the fields of the composite because the definition of non-final
+    composites should be possible to change without violating the backward compatibility.
+
+    If the bit length set was dependent on the field composition, then a composite $A$ that nests another composite
+    $B$ could have made a fragile assumption about the offset of the fields that follow $B$
+    that could be broken when $B$ is modified. Example:
+
+    \begin{minted}{python}
+        # A.1.0
+        B.1.0 x
+        float32 assume_aligned  # B.1.0 contains a single uint64, assume this field is 32-bit aligned?
+    \end{minted}
+
+    \begin{minted}{python}
+        # B.1.0
+        uint64 x
+    \end{minted}
+
+    Imagine then that \verb|B.1.0| is replaced with the following:
+
+    \begin{minted}{python}
+        # B.1.1
+        uint64 x
+        bool[<=64] y
+    \end{minted}
+
+    Once this modification is introduced, the fragile assumption about the alignment of
+    \verb|A.1.0.assume_aligned| would be violated.
+    To avoid this issue, the bit length set definition of non-final types intentionally discards the information
+    about its field composition, forcing dependent types to avoid any non-trivial assumptions.
+\end{remark}
 
 \subsubsection{Type polymorphism and equivalency}
 

--- a/specification/dsdl/serializable_types.tex
+++ b/specification/dsdl/serializable_types.tex
@@ -376,7 +376,7 @@ The extent should be at least as large as the longest serialized representation 
 which ensures that an agent leveraging a particular version can correctly process any other compatible
 version due to the avoidance of unintended truncation of serialized representations.
 
-Serialized representations of evolvable definitions carry additional metadata which introduces a certain overhead.
+Serialized representations of evolvable definitions may carry additional metadata which introduces a certain overhead.
 This may be undesirable in some scenarios, especially in cases where serialized representations of the
 definition are expected to be highly compact, thereby making the overhead comparatively more significant.
 In such cases, the designer may opt out of the extensibility by declaring the definition sealed.

--- a/specification/dsdl/serializable_types.tex
+++ b/specification/dsdl/serializable_types.tex
@@ -292,46 +292,40 @@ A tagged union shall not contain padding field attributes.
 The value of a tagged union object is a function of the field attribute which value it is currently holding
 and the value of the field attribute itself.
 
-\subsubsection{Extent and finality}
+\subsubsection{Extent and finality}\label{sec:dsdl_composite_extent_and_finality}
 
-\begin{figure}[H]
-    \centering
-    \begin{tabular}{r c c c c c}
-        \cline{2-5}
-        {\footnotesize{v1.0:}} &
-        \multicolumn{1}{|c|}{$a_0$} & \multicolumn{1}{c|}{$a_1$}
-        &\multicolumn{1}{c|}{$b_0$} & \multicolumn{1}{c|}{$b_1$} &
-        \\\cline{2-5}
-        & $\checkmark$ & $\checkmark$ & $\times$ & $\times$ & $\times$ \\
-        \cline{2-6}
-        {\footnotesize{v1.1:}} &
-        \multicolumn{1}{|c|}{$a_0$} & \multicolumn{1}{c|}{$a_1$} & \multicolumn{1}{c|}{$a_2$}
-        &\multicolumn{1}{c|}{$b_0$} & \multicolumn{1}{c|}{$b_1$}
-        \\\cline{2-6}
-    \end{tabular}
-    \caption{Non-extensibility of final types}
-    \label{fig:dsdl_final_non_extensibility}
-\end{figure}
+As detailed in section \ref{sec:dsdl_versioning},
+data types may evolve over time to accommodate new design requirements, new features, to rectify issues, etc.
+In order to allow gradual migration of deployed systems to revised data types,
+it is desirable to ensure that they can be modified in a way that does not render new definitions
+incompatible with their earlier versions.
+In this context there are two related concepts:
 
-\begin{figure}[H]
-    \centering
-    \begin{tabular}{r c c c c c c}
-        \cline{2-7}
-        {\footnotesize{v1.0:}} &
-        \multicolumn{1}{|c|}{$H_a$} & \multicolumn{1}{c|}{$a_0$} & \multicolumn{1}{c|}{$a_1$}
-        &\multicolumn{1}{c|}{\footnotesize{$\underset{\leftrightarrow}{\varnothing}$}}
-        &\multicolumn{1}{c|}{$b_0$} & \multicolumn{1}{c|}{$b_1$}
-        \\\cline{2-7}
-        & $\checkmark$ & $\checkmark$ & $\checkmark$ & $\checkmark$ & $\checkmark$ & $\checkmark$ \\
-        \cline{2-7}
-        {\footnotesize{v1.1:}} &
-        \multicolumn{1}{|c|}{$H_a$} & \multicolumn{1}{c|}{$a_0$} & \multicolumn{1}{c|}{$a_1$} & \multicolumn{1}{c|}{$a_2$}
-        &\multicolumn{1}{c|}{$b_0$} & \multicolumn{1}{c|}{$b_1$}
-        \\\cline{2-7}
-    \end{tabular}
-    \caption{Extensibility of non-final types with the help of the delimiter header}
-    \label{fig:dsdl_final_non_extensibility}
-\end{figure}
+\begin{description}
+    \item[Extent] --- the minimum amount of memory, in bits, that shall be allocated to store the serialized
+    representation of the schema.
+    The extent of any schema is always greater than or equal the maximal value of its bit length set.
+    It is always a multiple of 8.
+
+    \item[Finality] --- denotes whether a schema is \emph{final}.
+    A schema that is final is non-evolvable and its extent equals the maximal value of its bit length set\footnote{%
+        I.e., the smallest possible extent.
+    }.
+\end{description}
+
+The extent is the growth limit for the maximal bit length of the schema as it evolves.
+The requirement that the extent is at least as large as the longest serialized representation of
+any version of the schema ensures that an agent leveraging any of its versions can
+correctly process any other compatible version due to the avoidance of unintended truncation of
+serialized representations.
+
+Serialized representations of evolvable definitions carry additional metadata which introduces a certain overhead.
+This may be undesirable in some scenarios, especially in cases where serialized representations of the
+definition are expected to be highly compact, thereby making the overhead comparatively more significant.
+In such cases, the designer may opt out of the extensibility by declaring the definition final.
+Serialized representations of final definitions do not incur the aforementioned overhead.
+
+The related mechanics are described in section \ref{sec:dsdl_data_serialization} dedicated to data serialization.
 
 \begin{figure}[H]
     $$
@@ -339,17 +333,36 @@ and the value of the field attribute itself.
         \underbrace{%
             \blacksquare\blacksquare\blacksquare\blacksquare\blacksquare\blacksquare%
             \blacksquare\blacksquare\blacksquare\blacksquare\blacksquare\blacksquare%
-        }_{\substack{\text{Serialized data} \\ \text{exchanged over network}}}%
+        }_{\substack{\text{Longest serialized} \\ \text{representation}}}%
         \underbrace{%
             \boxtimes\boxtimes\boxtimes\boxtimes\boxtimes\boxtimes\boxtimes\boxtimes%
-        }_{\substack{\text{Local memory reserve} \\ \text{for extensibility}}}%
+        }_{\substack{\text{Memory reserve} \\ \text{(none if final)}}}%
     }^{\substack{%
         \text{Extent} \\
-        \text{(required buffer memory)}
+        \text{(memory requirement)}
     }}
     $$
-    \caption{Serialized bit length and extent\label{fig:dsdl_extent}}
+    \caption{Serialized representation and extent\label{fig:dsdl_extent}}
 \end{figure}
+
+The default extent of a non-final definition is the following function of its bit length set $B$:
+
+$$
+\text{Ext}_\text{default}\left(B\right) =
+\left\lceil{}\left\lfloor{}\frac{3}{2} \max{}\left(B\right)\right\rfloor{}/8\right\rceil{}8
+$$
+
+The extent can be set explicitly\footnote{
+    Observe that when composites are nested,
+    the default extent of an outer composite will be increasing as an exponential
+    function of the number of levels of nesting (because each level introduces the fixed multiplier).
+    Therefore, it is advised to specify the extent manually to manage the memory requirement.
+}
+using the directive described in section \ref{sec:dsdl_directive_extent},
+unless the definition is final.
+
+By default, a definition is not final unless explicitly indicated otherwise using the directive described in
+section \ref{sec:dsdl_directive_final}.
 
 \subsubsection{Type polymorphism and equivalency}
 

--- a/specification/dsdl/serializable_types.tex
+++ b/specification/dsdl/serializable_types.tex
@@ -512,6 +512,11 @@ as defined in section \ref{sec:dsdl_serialization_composite_non_final}.
     about its field composition, forcing dependent types to avoid any non-trivial assumptions.
 \end{remark}
 
+When serializing an object, the amount of memory needed for storing its serialized representation
+may be taken as the maximal value of its bit length set minus the size of the delimiter header,
+since this bound is tighter than the extent yet guaranteed to be sufficient.
+This optimization is not applicable to deserialization since the actual type of the object may not be known.
+
 \subsubsection{Type polymorphism and equivalency}
 
 Type polymorphism is supported in DSDL through structural subtyping.

--- a/specification/dsdl/serializable_types.tex
+++ b/specification/dsdl/serializable_types.tex
@@ -9,7 +9,8 @@ The data serialization rules are defined in section~\ref{sec:dsdl_data_serializa
 
 \subsubsection{Alignment and padding}\label{sec:dsdl_serializable_alignment_padding}
 
-For any type, its \emph{alignment} $A$ is defined as some positive integer number of bits such that the offset of a
+For any serializable type,
+its \emph{alignment} $A$ is defined as some positive integer number of bits such that the offset of a
 serialized representation of an instance of this type relative to the origin of the
 containing serialized representation (if any) is an integer multiple of $A$.
 
@@ -237,7 +238,7 @@ All versions of a data type shall be of the same kind\footnote{%
     For example, if a data type version 0.1 is of a message kind, all later versions of it shall be messages, too.
 }.
 
-A service type defines two inferior data types:
+A service type defines two unutterable inferior data types:
 one for service request object, and one for service response object, in that order.
 The two inferiors are separated by the service response marker (``\verb|---|'') on a separate line.
 
@@ -339,11 +340,13 @@ after its last element until the resulting length is a multiple of 8 bits.
 
 Given a set of field attributes, their \emph{cumulative bit length set} is computed
 by evaluating every permutation of their respective bit length sets plus the required padding.
-For tagged unions, this amounts to the union of the bit length sets of each field
-plus the bit length set of the implicit union tag prefix.
-Otherwise, the cumulative bit length set is the Cartesian product of the bit length sets of each field
-plus the required inter-field padding.
-The specifics are given in section \ref{sec:dsdl_data_serialization}.
+\begin{itemize}
+    \item For tagged unions, this amounts to the union of the bit length sets of each field
+    plus the bit length set of the implicit union tag prefix.
+    \item Otherwise, the cumulative bit length set is the Cartesian product of the bit length sets of each field
+    plus the required inter-field padding.
+\end{itemize}
+Related specifics are given in section \ref{sec:dsdl_data_serialization} on data serialization.
 
 \subsubsection{Extent and finality}\label{sec:dsdl_composite_extent_and_finality}
 
@@ -368,10 +371,9 @@ In this context there are two related concepts:
 \end{description}
 
 The extent is the growth limit for the maximal bit length of the type as it evolves.
-The requirement that the extent is at least as large as the longest serialized representation of
-any version of the type ensures that an agent leveraging any of its versions can
-correctly process any other compatible version due to the avoidance of unintended truncation of
-serialized representations.
+The extent should be at least as large as the longest serialized representation of any compatible version of the type,
+which ensures that an agent leveraging a particular version can correctly process any other compatible
+version due to the avoidance of unintended truncation of serialized representations.
 
 Serialized representations of evolvable definitions carry additional metadata which introduces a certain overhead.
 This may be undesirable in some scenarios, especially in cases where serialized representations of the
@@ -407,6 +409,27 @@ $$
 X_\text{default}\left(B\right) =
 \left\lceil{}\left\lfloor{}\frac{3}{2} \max{}\left(B\right)\right\rfloor{}/8\right\rceil{}8
 $$
+
+\begin{remark}
+    The extent of the following structure is 96 bits (12 bytes):
+    \begin{minted}{python}
+        uint16 foo
+        uint8[<=5] bar
+        @assert _offset_ == {24, 32, 40, 48, 56, 64}
+    \end{minted}
+    How it was computed: \verb|foo| is fixed-size at 16 bits,
+    the implicit array length prefix of \verb|bar| is 8 bits,
+    the maximum array body length is $8 \times 5$ bits:
+    $(16 + 8 + 8 \times 5) \times \frac{3}{2} = 96$ bits.
+
+    The extent of the following union is 88 bits (11 bytes):
+    \begin{minted}{python}
+        @union
+        uint16 foo
+        uint8[<=5] bar
+        @assert _offset_ == {16, 24, 32, 40, 48, 56}
+    \end{minted}
+\end{remark}
 
 The extent can be set explicitly\footnote{
     Observe that when composites are nested,
@@ -513,6 +536,7 @@ Let each field attribute be assigned a sequential index according to its positio
             (containing) type (if any).
             This circumstance effectively renders them non-modifiable because that may break the bit layout
             of the outer types (if any).
+            More on this in section \ref{sec:dsdl_serialization_composite_non_final}.
         };
         \item the extent of $B$ is not less than the extent of $D$\footnote{%
             This is to uphold the Liskov substitution principle.

--- a/specification/dsdl/serializable_types.tex
+++ b/specification/dsdl/serializable_types.tex
@@ -589,6 +589,14 @@ Let each field attribute be assigned a sequential index according to its positio
         \item the extent of $B$ is not less than the extent of $D$;
         \item $B$ is not $D$.
     \end{itemize}
+
+    % -----------------------------------------------------------------------------------------------------------------
+    \item Header subtyping rule --- $D$ is a structural subtype of $B$ if all conditions are satisfied:
+    \begin{itemize}
+        \item neither $B$ nor $D$ define a tagged union;
+        \item both $B$ and $D$ are sealed;
+        \item the first field attribute of $D$ is of type $B$.
+    \end{itemize}
 \end{enumerate}
 
 If $D$ is a structural subtype of $B$, then $B$ is a \emph{structural supertype} of $D$.
@@ -636,6 +644,22 @@ one type is a subtype of another, and for any member its supertypes are located 
     A message type that defines zero fields is a structural supertype of any other message type, regardless of either
     or both being a union.
     A message type may have an arbitrary number of supertypes as long as the field equality constraint is satisfied.
+
+    Header subtyping example. The first type is named \verb|A.1.0|:
+
+    \begin{minted}{python}
+        float64 a
+        int16[<=9] b
+        @sealed
+    \end{minted}
+
+    The second type is a structural subtype of the first type:
+
+    \begin{minted}{python}
+        A.1.0 base
+        uint8 foo
+        @sealed
+    \end{minted}
 \end{remark}
 
 \begin{remark}[breakable]

--- a/specification/dsdl/serializable_types.tex
+++ b/specification/dsdl/serializable_types.tex
@@ -292,6 +292,10 @@ A tagged union shall not contain padding field attributes.
 The value of a tagged union object is a function of the field attribute which value it is currently holding
 and the value of the field attribute itself.
 
+\subsubsection{Extent and finality}
+
+
+
 \subsubsection{Type polymorphism and equivalency}
 
 Type polymorphism is supported in DSDL through structural subtyping.
@@ -302,30 +306,65 @@ Let $B$ and $D$ be DSDL message types whose data schemas define $b$ and $d$ fiel
 Let each field attribute be assigned a sequential index according to its position in the DSDL definition
 (see section~\ref{sec:dsdl_grammar} on statement ordering).
 
-$D$ is a \emph{structural subtype} of $B$ if all conditions are satisfied:
-\begin{itemize}
-    \item neither $B$ nor $D$ define a tagged union;
-    \item $B$ is not $D$;
-    \item $b \leq d$;
-    \item for each field attribute of $B$ at index $i$ there is an equal\footnote{%
-              Field attribute equality is defined in section~\ref{sec:dsdl_attributes}.
-          } field attribute in $D$ at index $i$.
-\end{itemize}
+\begin{enumerate}
+    % -----------------------------------------------------------------------------------------------------------------
+    \item Structure subtyping rule --- $D$ is a \emph{structural subtype} of $B$ if all conditions are satisfied:
+    \begin{itemize}
+        \item neither $B$ nor $D$ define a tagged union\footnote{%
+            This is because tagged unions are serialized differently.
+        };
+        \item neither $B$ nor $D$ are final\footnote{%
+            Final types are serialized in-place as if their definition was directly copied into the outer (containing)
+            type (if any).
+            This circumstance effectively renders them non-modifiable because that may break the bit layout of the outer
+            types (if any).
+        };
+        \item the extent of $B$ is not less than the extent of $D$\footnote{%
+            This is to uphold the Liskov substitution principle.
+            A deserializer expecting an instance of $B$ in a serialized representation should be invariant
+            to the replacement $B \leftarrow{} D$.
+            If the extent of $D$ was larger, then its serialized representation could spill beyond the allocated
+            container, possibly resulting in the truncation of the following data, which in turn could result in
+            incorrect deserialization.
+            See \ref{sec:dsdl_data_serialization}.
+        };
+        \item $B$ is not $D$;
+        \item $b \leq d$;
+        \item for each field attribute of $B$ at index $i$ there is an equal\footnote{%
+                Field attribute equality is defined in section~\ref{sec:dsdl_attributes}.
+            } field attribute in $D$ at index $i$.
+    \end{itemize}
 
-$D$ is a structural subtype of $B$ if all conditions are satisfied:
-\begin{itemize}
-    \item both $B$ and $D$ define tagged unions;
-    \item $B$ is not $D$;
-    \item $b \leq d$;
-    \item $2^{\lceil\log_2 \text{max}\left(8, \lceil\log_2 b\rceil\right)\rceil} =
-           2^{\lceil\log_2 \text{max}\left(8, \lceil\log_2 d\rceil\right)\rceil}$;
-    \item for $i \in \left[0, b\right)$, the type of the field attribute of $D$ at index $i$
-          is the same or is a subtype of the type of the field attribute of $B$ at index $i$.
-    \item for $i \in \left[0, b\right)$, the name of the field attribute of $D$ at index $i$
-          is the same as the name of the field attribute of $B$ at index $i$.
-\end{itemize}
+    % -----------------------------------------------------------------------------------------------------------------
+    \item Tagged union subtyping rule --- $D$ is a structural subtype of $B$ if all conditions are satisfied:
+    \begin{itemize}
+        \item both $B$ and $D$ define tagged unions;
+        \item neither $B$ nor $D$ are final;
+        \item the extent of $B$ is not less than the extent of $D$;
+        \item $B$ is not $D$;
+        \item $b \leq d$;
+        \item $2^{\lceil\log_2 \text{max}\left(8, \lceil\log_2 b\rceil\right)\rceil} =
+               2^{\lceil\log_2 \text{max}\left(8, \lceil\log_2 d\rceil\right)\rceil}$\footnote{%
+                  I.e., the length of the implicit union tag field should be the same.
+              };
+        \item for $i \in \left[0, b\right)$, the type of the field attribute of $D$ at index $i$
+            is the same or is a subtype of the type of the field attribute of $B$ at index $i$.
+        \item for $i \in \left[0, b\right)$, the name of the field attribute of $D$ at index $i$
+            is the same as the name of the field attribute of $B$ at index $i$.
+    \end{itemize}
 
-$D$ is a structural subtype of $B$ if $b = 0$.
+    % -----------------------------------------------------------------------------------------------------------------
+    \item Empty schema subtyping rule --- $D$ is a structural subtype of $B$ if all conditions are satisfied:
+    \begin{itemize}
+        \item $b = 0$\footnote{%
+            If $B$ contains no field attributes, the applicability of the Liskov substitution principle is invariant to
+            whether its subtypes are tagged union types or not.
+        };
+        \item neither $B$ nor $D$ are final;
+        \item the extent of $B$ is not less than the extent of $D$;
+        \item $B$ is not $D$.
+    \end{itemize}
+\end{enumerate}
 
 If $D$ is a structural subtype of $B$, then $B$ is a \emph{structural supertype} of $D$.
 

--- a/specification/dsdl/serializable_types.tex
+++ b/specification/dsdl/serializable_types.tex
@@ -232,16 +232,14 @@ The alignment of an array equals the alignment of its element type\footnote{
 
 \subsubsection{Kinds}
 
-There are two kinds of composite data type definitions: message types and service types.
+There are two kinds of composite type definitions: message types and service types.
 All versions of a data type shall be of the same kind\footnote{%
     For example, if a data type version 0.1 is of a message kind, all later versions of it shall be messages, too.
 }.
 
-A message data type defines one data schema.
-
-A service data type contains two data schema definitions:
+A service type defines two inferior data types:
 one for service request object, and one for service response object, in that order.
-The two schemas are separated by the service response marker (``\verb|---|'') on a separate line.
+The two inferiors are separated by the service response marker (``\verb|---|'') on a separate line.
 
 The presence of the service response marker indicates that the data type definition at hand is of the service kind.
 At most one service response marker shall appear in a given definition.
@@ -316,16 +314,16 @@ The available attributes and their semantics are documented in the section~\ref{
 
 \subsubsection{Tagged unions}\label{sec:dsdl_composite_tagged_unions}
 
-Any data schema definition can be supplied with a special directive (section~\ref{sec:dsdl_directives})
+Any data type definition can be supplied with a special directive (section~\ref{sec:dsdl_directives})
 indicating that it forms a tagged union.
 
-A tagged union schema shall contain at least two field attributes.
+A tagged union type shall contain at least two field attributes.
 A tagged union shall not contain padding field attributes.
 
 The value of a tagged union object is a function of the field attribute which value it is currently holding
 and the value of the field attribute itself.
 
-To avoid ambiguity, a data schema that is not a tagged union is referred to as a \emph{structure}.
+To avoid ambiguity, a data type that is not a tagged union is referred to as a \emph{structure}.
 
 \subsubsection{Alignment and cumulative bit length set}\label{sec:dsdl_composite_alignment_cumulative_bls}
 
@@ -358,20 +356,20 @@ In this context there are two related concepts:
 
 \begin{description}
     \item[Extent] --- the minimum amount of memory, in bits, that shall be allocated to store the serialized
-    representation of the schema.
-    The extent of any schema is always greater than or equal the maximal value of its bit length set.
+    representation of the type.
+    The extent of any type is always greater than or equal the maximal value of its bit length set.
     It is always a multiple of 8.
 
-    \item[Finality] --- denotes whether a schema is \emph{final}.
-    A schema that is final is non-evolvable and its extent equals the maximal value of its bit length set\footnote{%
+    \item[Finality] --- denotes whether a type is \emph{final}.
+    A type that is final is non-evolvable and its extent equals the maximal value of its bit length set\footnote{%
         I.e., the smallest possible extent.
     }.
-    A schema that is not final is also referred to as \emph{delimited}.
+    A type that is not final is also referred to as \emph{delimited}.
 \end{description}
 
-The extent is the growth limit for the maximal bit length of the schema as it evolves.
+The extent is the growth limit for the maximal bit length of the type as it evolves.
 The requirement that the extent is at least as large as the longest serialized representation of
-any version of the schema ensures that an agent leveraging any of its versions can
+any version of the type ensures that an agent leveraging any of its versions can
 correctly process any other compatible version due to the avoidance of unintended truncation of
 serialized representations.
 
@@ -497,7 +495,9 @@ Type polymorphism is supported in DSDL through structural subtyping.
 The following definition relies on the concept of \emph{field attribute},
 which is introduced in section~\ref{sec:dsdl_attributes}.
 
-Let $B$ and $D$ be DSDL message types whose data schemas define $b$ and $d$ field attributes, respectively.
+Polymorphic relations are not defined on service types.
+
+Let $B$ and $D$ be DSDL types that define $b$ and $d$ field attributes, respectively.
 Let each field attribute be assigned a sequential index according to its position in the DSDL definition
 (see section~\ref{sec:dsdl_grammar} on statement ordering).
 
@@ -509,10 +509,10 @@ Let each field attribute be assigned a sequential index according to its positio
             This is because tagged unions are serialized differently.
         };
         \item neither $B$ nor $D$ are final\footnote{%
-            Final types are serialized in-place as if their definition was directly copied into the outer (containing)
-            type (if any).
-            This circumstance effectively renders them non-modifiable because that may break the bit layout of the outer
-            types (if any).
+            Final types are serialized in-place as if their definition was directly copied into the outer
+            (containing) type (if any).
+            This circumstance effectively renders them non-modifiable because that may break the bit layout
+            of the outer types (if any).
         };
         \item the extent of $B$ is not less than the extent of $D$\footnote{%
             This is to uphold the Liskov substitution principle.
@@ -526,8 +526,8 @@ Let each field attribute be assigned a sequential index according to its positio
         \item $B$ is not $D$;
         \item $b \leq d$;
         \item for each field attribute of $B$ at index $i$ there is an equal\footnote{%
-                Field attribute equality is defined in section~\ref{sec:dsdl_attributes}.
-            } field attribute in $D$ at index $i$.
+            Field attribute equality is defined in section~\ref{sec:dsdl_attributes}.
+        } field attribute in $D$ at index $i$.
     \end{itemize}
 
     % -----------------------------------------------------------------------------------------------------------------
@@ -540,16 +540,16 @@ Let each field attribute be assigned a sequential index according to its positio
         \item $b \leq d$;
         \item $2^{\lceil\log_2 \text{max}\left(8, \lceil\log_2 b\rceil\right)\rceil} =
                2^{\lceil\log_2 \text{max}\left(8, \lceil\log_2 d\rceil\right)\rceil}$\footnote{%
-                  I.e., the length of the implicit union tag field should be the same.
-              };
+            I.e., the length of the implicit union tag field should be the same.
+        };
         \item for $i \in \left[0, b\right)$, the type of the field attribute of $D$ at index $i$
-            is the same or is a subtype of the type of the field attribute of $B$ at index $i$.
+        is the same or is a subtype of the type of the field attribute of $B$ at index $i$.
         \item for $i \in \left[0, b\right)$, the name of the field attribute of $D$ at index $i$
-            is the same as the name of the field attribute of $B$ at index $i$.
+        is the same as the name of the field attribute of $B$ at index $i$.
     \end{itemize}
 
     % -----------------------------------------------------------------------------------------------------------------
-    \item Empty schema subtyping rule --- $D$ is a structural subtype of $B$ if all conditions are satisfied:
+    \item Empty type subtyping rule --- $D$ is a structural subtype of $B$ if all conditions are satisfied:
     \begin{itemize}
         \item $b = 0$\footnote{%
             If $B$ contains no field attributes, the applicability of the Liskov substitution principle is invariant to
@@ -606,9 +606,6 @@ one type is a subtype of another, and for any member its supertypes are located 
     A message type that defines zero fields is a structural supertype of any other message type, regardless of either
     or both being a union.
     A message type may have an arbitrary number of supertypes as long as the field equality constraint is satisfied.
-
-    Polymorphic relations are not defined on service types;
-    however, this may change in a future revision of the standard.
 \end{remark}
 
 \begin{remark}[breakable]

--- a/specification/dsdl/serializable_types.tex
+++ b/specification/dsdl/serializable_types.tex
@@ -238,9 +238,9 @@ All versions of a data type shall be of the same kind\footnote{%
     For example, if a data type version 0.1 is of a message kind, all later versions of it shall be messages, too.
 }.
 
-A service type defines two unutterable inferior data types:
+A service type defines two inner data types:
 one for service request object, and one for service response object, in that order.
-The two inferiors are separated by the service response marker (``\verb|---|'') on a separate line.
+The two types are separated by the service response marker (``\verb|---|'') on a separate line.
 
 The presence of the service response marker indicates that the data type definition at hand is of the service kind.
 At most one service response marker shall appear in a given definition.

--- a/specification/dsdl/serializable_types.tex
+++ b/specification/dsdl/serializable_types.tex
@@ -342,7 +342,7 @@ Given a set of field attributes, their \emph{cumulative bit length set} is compu
 by evaluating every permutation of their respective bit length sets plus the required padding.
 \begin{itemize}
     \item For tagged unions, this amounts to the union of the bit length sets of each field
-    plus the bit length set of the implicit union tag prefix.
+    plus the bit length set of the implicit union tag.
     \item Otherwise, the cumulative bit length set is the Cartesian product of the bit length sets of each field
     plus the required inter-field padding.
 \end{itemize}

--- a/specification/dsdl/serializable_types.tex
+++ b/specification/dsdl/serializable_types.tex
@@ -380,7 +380,7 @@ definition are expected to be highly compact, thereby making the overhead compar
 In such cases, the designer may opt out of the extensibility by declaring the definition final.
 Serialized representations of final definitions do not incur the aforementioned overhead.
 
-The related mechanics are described in section \ref{sec:dsdl_data_serialization} dedicated to data serialization.
+The related mechanics are described in section \ref{sec:dsdl_serialization_composite_non_final}.
 
 \begin{figure}[H]
     $$
@@ -420,6 +420,8 @@ unless the definition is final.
 
 By default, a definition is not final unless explicitly indicated otherwise using the directive described in
 section \ref{sec:dsdl_directive_final}.
+
+It is allowed for a final composite type to nest non-final composite types, and vice versa.
 
 \subsubsection{Bit length set}
 

--- a/specification/dsdl/serializable_types.tex
+++ b/specification/dsdl/serializable_types.tex
@@ -366,6 +366,7 @@ In this context there are two related concepts:
     A schema that is final is non-evolvable and its extent equals the maximal value of its bit length set\footnote{%
         I.e., the smallest possible extent.
     }.
+    A schema that is not final is also referred to as \emph{delimited}.
 \end{description}
 
 The extent is the growth limit for the maximal bit length of the schema as it evolves.
@@ -400,7 +401,7 @@ The related mechanics are described in section \ref{sec:dsdl_serialization_compo
     \caption{Serialized representation and extent\label{fig:dsdl_extent}}
 \end{figure}
 
-The default extent of a non-final definition is the following function
+The default extent of a non-final (delimited) definition is the following function
 of the cumulative bit length set\footnote{Section \ref{sec:dsdl_composite_alignment_cumulative_bls}.}
 of its fields $B$:
 
@@ -421,7 +422,7 @@ unless the definition is final.
 By default, a definition is not final unless explicitly indicated otherwise using the directive described in
 section \ref{sec:dsdl_directive_final}.
 
-It is allowed for a final composite type to nest non-final composite types, and vice versa.
+It is allowed for a final composite type to nest non-final (delimited) composite types, and vice versa.
 
 \subsubsection{Bit length set}
 
@@ -449,7 +450,8 @@ of its fields plus the final padding (see section \ref{sec:dsdl_composite_alignm
     \end{minted}
 \end{remark}
 
-The bit length set of a non-final composite type is dependent only on its extent $X$, and is defined as follows:
+The bit length set of a non-final (delimited) composite type is dependent only on its extent $X$,
+and is defined as follows:
 $$
     \left\{ B_\text{DH} + 8b \mid b \in \mathbb{Z},\ 0 \leq b \leq \frac{X}{8} \right\}
 $$
@@ -457,7 +459,7 @@ where $B_\text{DH}$ is the bit length of the \emph{delimiter header}
 as defined in section \ref{sec:dsdl_serialization_composite_non_final}.
 
 \begin{remark}
-    This is intentionally not dependent on the fields of the composite because the definition of non-final
+    This is intentionally not dependent on the fields of the composite because the definition of delimited
     composites should be possible to change without violating the backward compatibility.
 
     If the bit length set was dependent on the field composition, then a composite $A$ that nests another composite
@@ -485,7 +487,7 @@ as defined in section \ref{sec:dsdl_serialization_composite_non_final}.
 
     Once this modification is introduced, the fragile assumption about the alignment of
     \verb|A.1.0.assume_aligned| would be violated.
-    To avoid this issue, the bit length set definition of non-final types intentionally discards the information
+    To avoid this issue, the bit length set definition of delimited types intentionally discards the information
     about its field composition, forcing dependent types to avoid any non-trivial assumptions.
 \end{remark}
 

--- a/specification/dsdl/serializable_types.tex
+++ b/specification/dsdl/serializable_types.tex
@@ -29,7 +29,8 @@ During deserialization, the padding bits are ignored (skipped) irrespective of t
     followed by a field whose type has the alignment requirement of 8,
     one may end up with 5, 6, or 7 bits of padding inserted before the second field at runtime.
 
-    The exact amount of such padding cannot always be determined statically because it depends on a runtime value;
+    The exact amount of such padding cannot always be determined statically because it depends on the size of the
+    preceding entity;
     however, it is guaranteed that it is always strictly less than the alignment requirement of the following field
     or, if this is the last field in a group, the alignment requirement of its container.
 \end{remark}

--- a/specification/dsdl/serializable_types.tex
+++ b/specification/dsdl/serializable_types.tex
@@ -348,7 +348,7 @@ by evaluating every permutation of their respective bit length sets plus the req
 \end{itemize}
 Related specifics are given in section \ref{sec:dsdl_data_serialization} on data serialization.
 
-\subsubsection{Extent and finality}\label{sec:dsdl_composite_extent_and_finality}
+\subsubsection{Extent and sealing}\label{sec:dsdl_composite_extent_and_sealing}
 
 As detailed in section \ref{sec:dsdl_versioning},
 data types may evolve over time to accommodate new design requirements, new features, to rectify issues, etc.
@@ -363,11 +363,11 @@ In this context there are two related concepts:
     The extent of any type is always greater than or equal the maximal value of its bit length set.
     It is always a multiple of 8.
 
-    \item[Finality] --- denotes whether a type is \emph{final}.
-    A type that is final is non-evolvable and its extent equals the maximal value of its bit length set\footnote{%
+    \item[Sealing] --- a type that is \emph{sealed} is non-evolvable and its extent equals the maximal value
+    of its bit length set\footnote{%
         I.e., the smallest possible extent.
     }.
-    A type that is not final is also referred to as \emph{delimited}.
+    A type that is not sealed is also referred to as \emph{delimited}.
 \end{description}
 
 The extent is the growth limit for the maximal bit length of the type as it evolves.
@@ -378,10 +378,10 @@ version due to the avoidance of unintended truncation of serialized representati
 Serialized representations of evolvable definitions carry additional metadata which introduces a certain overhead.
 This may be undesirable in some scenarios, especially in cases where serialized representations of the
 definition are expected to be highly compact, thereby making the overhead comparatively more significant.
-In such cases, the designer may opt out of the extensibility by declaring the definition final.
-Serialized representations of final definitions do not incur the aforementioned overhead.
+In such cases, the designer may opt out of the extensibility by declaring the definition sealed.
+Serialized representations of sealed definitions do not incur the aforementioned overhead.
 
-The related mechanics are described in section \ref{sec:dsdl_serialization_composite_non_final}.
+The related mechanics are described in section \ref{sec:dsdl_serialization_composite_non_sealed}.
 
 \begin{figure}[H]
     $$
@@ -392,7 +392,7 @@ The related mechanics are described in section \ref{sec:dsdl_serialization_compo
         }_{\substack{\text{Longest serialized} \\ \text{representation}}}%
         \underbrace{%
             \boxtimes\boxtimes\boxtimes\boxtimes\boxtimes\boxtimes\boxtimes\boxtimes%
-        }_{\substack{\text{Memory reserve} \\ \text{(none if final)}}}%
+        }_{\substack{\text{Memory reserve} \\ \text{(none if sealed)}}}%
     }^{\substack{%
         \text{Extent} \\
         \text{(memory requirement)}
@@ -401,7 +401,7 @@ The related mechanics are described in section \ref{sec:dsdl_serialization_compo
     \caption{Serialized representation and extent\label{fig:dsdl_extent}}
 \end{figure}
 
-The default extent of a non-final (delimited) definition is the following function
+The default extent of a non-sealed (delimited) definition is the following function
 of the cumulative bit length set\footnote{Section \ref{sec:dsdl_composite_alignment_cumulative_bls}.}
 of its fields $B$:
 
@@ -438,46 +438,46 @@ The extent can be set explicitly\footnote{
     Therefore, it is advised to specify the extent manually to manage the memory requirement.
 }
 using the directive described in section \ref{sec:dsdl_directive_extent},
-unless the definition is final.
+unless the definition is sealed.
 
-By default, a definition is not final unless explicitly indicated otherwise using the directive described in
-section \ref{sec:dsdl_directive_final}.
+By default, a definition is not sealed unless explicitly indicated otherwise using the directive described in
+section \ref{sec:dsdl_directive_sealed}.
 
-It is allowed for a final composite type to nest non-final (delimited) composite types, and vice versa.
+It is allowed for a sealed composite type to nest non-sealed (delimited) composite types, and vice versa.
 
 \subsubsection{Bit length set}
 
-The bit length set of a final composite type equals the cumulative bit length set
+The bit length set of a sealed composite type equals the cumulative bit length set
 of its fields plus the final padding (see section \ref{sec:dsdl_composite_alignment_cumulative_bls}).
 
 \begin{remark}
     The bit length set of the following is $\left\{ 8, 24, 40, 56 \right\}$:
     \begin{minted}{python}
         uint16[<=3] foo
-        @final
+        @sealed
     \end{minted}
 
     The bit length set of the following is $\left\{ 16, 32, 48, 64 \right\}$:
     \begin{minted}{python}
         uint16[<=3] foo
         int2 bar
-        @final
+        @sealed
     \end{minted}
 
     The bit length set of the following is $\left\{ 8, 16 \right\}$:
     \begin{minted}{python}
         bool[<=3] foo
-        @final
+        @sealed
     \end{minted}
 \end{remark}
 
-The bit length set of a non-final (delimited) composite type is dependent only on its extent $X$,
+The bit length set of a non-sealed (delimited) composite type is dependent only on its extent $X$,
 and is defined as follows:
 $$
     \left\{ B_\text{DH} + 8b \mid b \in \mathbb{Z},\ 0 \leq b \leq \frac{X}{8} \right\}
 $$
 where $B_\text{DH}$ is the bit length of the \emph{delimiter header}
-as defined in section \ref{sec:dsdl_serialization_composite_non_final}.
+as defined in section \ref{sec:dsdl_serialization_composite_non_sealed}.
 
 \begin{remark}
     This is intentionally not dependent on the fields of the composite because the definition of delimited
@@ -536,12 +536,12 @@ Let each field attribute be assigned a sequential index according to its positio
         \item neither $B$ nor $D$ define a tagged union\footnote{%
             This is because tagged unions are serialized differently.
         };
-        \item neither $B$ nor $D$ are final\footnote{%
-            Final types are serialized in-place as if their definition was directly copied into the outer
+        \item neither $B$ nor $D$ are sealed\footnote{%
+            Sealed types are serialized in-place as if their definition was directly copied into the outer
             (containing) type (if any).
             This circumstance effectively renders them non-modifiable because that may break the bit layout
             of the outer types (if any).
-            More on this in section \ref{sec:dsdl_serialization_composite_non_final}.
+            More on this in section \ref{sec:dsdl_serialization_composite_non_sealed}.
         };
         \item the extent of $B$ is not less than the extent of $D$\footnote{%
             This is to uphold the Liskov substitution principle.
@@ -563,7 +563,7 @@ Let each field attribute be assigned a sequential index according to its positio
     \item Tagged union subtyping rule --- $D$ is a structural subtype of $B$ if all conditions are satisfied:
     \begin{itemize}
         \item both $B$ and $D$ define tagged unions;
-        \item neither $B$ nor $D$ are final;
+        \item neither $B$ nor $D$ are sealed;
         \item the extent of $B$ is not less than the extent of $D$;
         \item $B$ is not $D$;
         \item $b \leq d$;
@@ -584,7 +584,7 @@ Let each field attribute be assigned a sequential index according to its positio
             If $B$ contains no field attributes, the applicability of the Liskov substitution principle is invariant to
             whether its subtypes are tagged union types or not.
         };
-        \item neither $B$ nor $D$ are final;
+        \item neither $B$ nor $D$ are sealed;
         \item the extent of $B$ is not less than the extent of $D$;
         \item $B$ is not $D$.
     \end{itemize}

--- a/specification/dsdl/serializable_types.tex
+++ b/specification/dsdl/serializable_types.tex
@@ -1,15 +1,42 @@
 \section{Serializable types}\label{sec:dsdl_serializable_types}
 
+\subsection{General principles}
+
 Values of the serializable type category can be exchanged between nodes over the UAVCAN network.
 This is opposed to the expression types (section~\ref{sec:dsdl_expression_types}),
 instances of which can only exist while DSDL definitions are being evaluated.
 The data serialization rules are defined in section~\ref{sec:dsdl_data_serialization}.
 
+\subsubsection{Alignment and padding}
+
+For any type, its \emph{alignment} $A$ is defined as some positive integer number of bits such that the offset of a
+serialized representation of an instance of this type relative to the origin of the
+containing serialized representation (if any) is an integer multiple of $A$.
+
+Given an instance of type whose alignment is $A$,
+it is guaranteed that its serialized representation is always an integer multiple of $A$ bits long.
+
+When constructing a serialized representation,
+the alignment and length requirements are satisfied by means of \emph{padding},
+which refers to the extension of a bit sequence with zero bits until
+the resulting alignment or length requirements are satisfied.
+During deserialization, the padding bits are ignored (skipped) irrespective of their value
+(also see related section \ref{sec:dsdl_serialization_implicit_truncation}).
+
+\begin{remark}
+    For example, given a variable-length entity whose length varies between 1 and 3 bits,
+    followed by a field whose type has the alignment requirement of 8,
+    one may end up with 5, 6, or 7 bits of padding inserted before the second field at runtime.
+
+    The exact amount of such padding cannot always be determined statically because it depends on a runtime value;
+    however, it is guaranteed that it is always strictly less than the alignment requirement of the following field
+    or, if this is the last field in a group, the alignment requirement of its container.
+\end{remark}
+
 \subsection{Void types}
 
 Void types are used for padding purposes.
-As will be explained in later sections, it is desirable to align field attributes at byte boundaries;
-void types can be used to facilitate that.
+The alignment of void types is 1 bit (i.e., no alignment).
 
 Void-typed field attributes are set to zero when an object is serialized and ignored when it is deserialized.
 Void types can be used to reserve space in data type definitions for possible use in later versions of the data type.
@@ -25,6 +52,8 @@ Void types can be referred to directly by their name from any namespace.
 Primitive types are assumed to be known to DSDL processing tools a priori,
 and as such, they need not be defined by the user.
 Primitive types can be referred to directly by their name from any namespace.
+
+The alignment of primitive types is 1 bit (i.e., no alignment).
 
 \subsubsection{Hierarchy}
 
@@ -195,7 +224,17 @@ a variable-length array:
 \end{itemize}
 If neither of the above prefixes are provided, the resultant definition is that of a fixed-length array.
 
+The alignment of an array equals the alignment of its element type\footnote{
+    E.g., the alignment of \texttt{uint5[<=3]} or \texttt{int64[3]} is 1 bit (that is, no alignment).
+}.
+
 \subsection{Composite types}\label{sec:dsdl_composite_types}
+
+The alignment of composite types is one byte (8 bits)\footnote{%
+    Regardless of the content.
+    It follows that empty composites can be inserted arbitrarily to force byte alignment
+    of the next field(s) at runtime.
+}.
 
 \subsubsection{Kinds}
 

--- a/specification/dsdl/serializable_types.tex
+++ b/specification/dsdl/serializable_types.tex
@@ -294,7 +294,62 @@ and the value of the field attribute itself.
 
 \subsubsection{Extent and finality}
 
+\begin{figure}[H]
+    \centering
+    \begin{tabular}{r c c c c c}
+        \cline{2-5}
+        {\footnotesize{v1.0:}} &
+        \multicolumn{1}{|c|}{$a_0$} & \multicolumn{1}{c|}{$a_1$}
+        &\multicolumn{1}{c|}{$b_0$} & \multicolumn{1}{c|}{$b_1$} &
+        \\\cline{2-5}
+        & $\checkmark$ & $\checkmark$ & $\times$ & $\times$ & $\times$ \\
+        \cline{2-6}
+        {\footnotesize{v1.1:}} &
+        \multicolumn{1}{|c|}{$a_0$} & \multicolumn{1}{c|}{$a_1$} & \multicolumn{1}{c|}{$a_2$}
+        &\multicolumn{1}{c|}{$b_0$} & \multicolumn{1}{c|}{$b_1$}
+        \\\cline{2-6}
+    \end{tabular}
+    \caption{Non-extensibility of final types}
+    \label{fig:dsdl_final_non_extensibility}
+\end{figure}
 
+\begin{figure}[H]
+    \centering
+    \begin{tabular}{r c c c c c c}
+        \cline{2-7}
+        {\footnotesize{v1.0:}} &
+        \multicolumn{1}{|c|}{$H_a$} & \multicolumn{1}{c|}{$a_0$} & \multicolumn{1}{c|}{$a_1$}
+        &\multicolumn{1}{c|}{\footnotesize{$\underset{\leftrightarrow}{\varnothing}$}}
+        &\multicolumn{1}{c|}{$b_0$} & \multicolumn{1}{c|}{$b_1$}
+        \\\cline{2-7}
+        & $\checkmark$ & $\checkmark$ & $\checkmark$ & $\checkmark$ & $\checkmark$ & $\checkmark$ \\
+        \cline{2-7}
+        {\footnotesize{v1.1:}} &
+        \multicolumn{1}{|c|}{$H_a$} & \multicolumn{1}{c|}{$a_0$} & \multicolumn{1}{c|}{$a_1$} & \multicolumn{1}{c|}{$a_2$}
+        &\multicolumn{1}{c|}{$b_0$} & \multicolumn{1}{c|}{$b_1$}
+        \\\cline{2-7}
+    \end{tabular}
+    \caption{Extensibility of non-final types with the help of the delimiter header}
+    \label{fig:dsdl_final_non_extensibility}
+\end{figure}
+
+\begin{figure}[H]
+    $$
+    \overbrace{%
+        \underbrace{%
+            \blacksquare\blacksquare\blacksquare\blacksquare\blacksquare\blacksquare%
+            \blacksquare\blacksquare\blacksquare\blacksquare\blacksquare\blacksquare%
+        }_{\substack{\text{Serialized data} \\ \text{exchanged over network}}}%
+        \underbrace{%
+            \boxtimes\boxtimes\boxtimes\boxtimes\boxtimes\boxtimes\boxtimes\boxtimes%
+        }_{\substack{\text{Local memory reserve} \\ \text{for extensibility}}}%
+    }^{\substack{%
+        \text{Extent} \\
+        \text{(required buffer memory)}
+    }}
+    $$
+    \caption{Serialized bit length and extent\label{fig:dsdl_extent}}
+\end{figure}
 
 \subsubsection{Type polymorphism and equivalency}
 

--- a/specification/dsdl/serializable_types.tex
+++ b/specification/dsdl/serializable_types.tex
@@ -402,7 +402,7 @@ The related mechanics are described in section \ref{sec:dsdl_serialization_compo
     \caption{Serialized representation and extent\label{fig:dsdl_extent}}
 \end{figure}
 
-The default extent of a non-sealed (delimited) definition is the following function
+Where a non-sealed (delimited) type is defined \emph{without} an explicit extent value a default memory reserve is implied using the following function
 of the cumulative bit length set\footnote{Section \ref{sec:dsdl_composite_alignment_cumulative_bls}.}
 of its fields $B$:
 

--- a/specification/dsdl/serializable_types.tex
+++ b/specification/dsdl/serializable_types.tex
@@ -412,6 +412,25 @@ X_\text{default}\left(B\right) =
 $$
 
 \begin{remark}
+    Because of UAVCAN's commitment to determinism, memory buffer allocation can become an issue.
+    When using a flat composite type (where each field is of a primitive type) with the implicit truncation rule,
+    it is clear that the last defined fields are to be truncated out shall the allocated buffer be too small
+    to accommodate the serialized representation in its entirety.
+    If there is a composite-typed field, this behavior can no longer be relied on.
+    The technical details explaining this are given in section \ref{sec:dsdl_serialization_composite_non_sealed}.
+
+    Conventional protocols manage this simply by delaying the memory requirement identification until runtime,
+    which is unacceptable to UAVCAN.
+    The solution for UAVCAN is to require implementations to reserve more memory than required
+    by the data type definition unless it is \verb|@sealed|
+    (or unless the implementation does use dynamic memory allocation).
+    The multiplier chosen to define the \emph{default} amount of reserve memory
+    (i.e., the amount if a specific extent value is not provided) was chosen arbitrarily
+    and is considered a common-sense default that is not optimized for any specific property of a system.
+    This approach allows for limited extensibility while enabling deterministic memory requirements.
+\end{remark}
+
+\begin{remark}
     The extent of the following structure is 96 bits (12 bytes):
     \begin{minted}{python}
         uint16 foo

--- a/specification/dsdl/serialization.tex
+++ b/specification/dsdl/serialization.tex
@@ -158,11 +158,11 @@ This behavior facilitates usage of void fields as placeholders for non-void fiel
 introduced in newer versions of the data type (section~\ref{sec:dsdl_versioning}).
 
 \begin{remark}
-    The following data schema will be serialized as a sequence of three zero bits $000_2$:
+    The following data type will be serialized as a sequence of three zero bits $000_2$:
     \begin{minted}{python}
         void3
     \end{minted}
-    The following bit sequences are valid serialized representations of the schema:
+    The following bit sequences are valid serialized representations of the type:
     $000_2$,
     $001_2$,
     $010_2$,
@@ -302,7 +302,7 @@ Serialized representations of a fixed-length array of $n$ elements of type $T$ a
 a sequence of $n$ field attributes of type $T$ are equivalent.
 
 \begin{remark}
-    Serialized representations of the following two data schema definitions are equivalent:
+    Serialized representations of the following two data type definitions are equivalent:
 
     \begin{minted}{python}
         AnyType[3] array
@@ -382,11 +382,6 @@ a fixed-length array of $n$ elements\footnote{%
 
 \subsection{Composite types}\label{sec:dsdl_serialization_composite}
 
-As explained in the section~\ref{sec:dsdl_composite_types}, a data type of the service kind contains
-two data schema definitions: one for the request object and one for the response object.
-Unless explicitly specified otherwise, any reference to serialized representations of a service type
-implies either or both of its data schema definitions, depending on context.
-
 \subsubsection{Final structure}
 
 A serialized representation of an object of a final composite type that is not a tagged union
@@ -396,7 +391,7 @@ The ordering of the serialized representations of the field attribute values fol
 of field attribute declaration.
 
 \begin{remark}
-    Consider the following data schema definition,
+    Consider the following definition,
     where the fields are assigned runtime values shown in the comments:
 
     \begin{minted}{python}
@@ -531,7 +526,7 @@ the serialized representation of the currently selected field attribute value\fo
     \end{minted}
 
     In order to encode the field \verb|b|, the implicit union tag shall be assigned the value 1.
-    The following data schema will have an identical layout:
+    The following type will have an identical layout:
 
     \begin{minted}{python}
         @final
@@ -561,7 +556,7 @@ the serialized representation of the currently selected field attribute value\fo
         @final
     \end{minted}
 
-    Consider the following union schema definition:
+    Consider the following union:
 
     \begin{minted}{python}
         @final
@@ -570,7 +565,7 @@ the serialized representation of the currently selected field attribute value\fo
         AnyType.1.0 some
     \end{minted}
 
-    The set of serialized representations of the union schema definition given above is equivalent to
+    The set of serialized representations of the union given above is equivalent to
     that of the following variable-length array:
 
     \begin{minted}{python}
@@ -666,7 +661,8 @@ No special rules apply in such cases.
             & $\checkmark$ & $\checkmark$ & $\checkmark$ & $\checkmark$ & $\checkmark$ & $\checkmark$ \\
             \cline{2-7}
             $C^\prime$ &
-            \multicolumn{1}{|c|}{$H_A$} & \multicolumn{1}{c|}{$a_0$} & \multicolumn{1}{c|}{$a_1$} & \multicolumn{1}{c|}{$a_2$}
+            \multicolumn{1}{|c|}{$H_A$} & \multicolumn{1}{c|}{$a_0$} & \multicolumn{1}{c|}{$a_1$} &
+            \multicolumn{1}{c|}{$a_2$}
             &\multicolumn{1}{c|}{$b_0$} & \multicolumn{1}{c|}{$b_1$}
             \\\cline{2-7}
         \end{tabular}

--- a/specification/dsdl/serialization.tex
+++ b/specification/dsdl/serialization.tex
@@ -380,15 +380,18 @@ a fixed-length array of $n$ elements\footnote{%
     \end{minted}
 \end{remark}
 
-\subsection{Composite types}
+\subsection{Composite types}\label{sec:dsdl_serialization_composite}
 
 As explained in the section~\ref{sec:dsdl_composite_types}, a data type of the service kind contains
 two data schema definitions: one for the request object and one for the response object.
 Unless explicitly specified otherwise, any reference to serialized representations of a service type
 implies either or both of its data schema definitions, depending on context.
 
-A serialized representation of an object of a composite type is a sequence of serialized representations of
-its field attribute values joined into a bit sequence.
+\subsubsection{Final structure}
+
+A serialized representation of an object of a final composite type that is not a tagged union
+is a sequence of serialized representations of its field attribute values joined into a bit sequence,
+separated by padding if such is necessary to satisfy the alignment requirements.
 The ordering of the serialized representations of the field attribute values follows the order
 of field attribute declaration.
 
@@ -479,7 +482,7 @@ of field attribute declaration.
     not recommended because the convention is deeply ingrained in most readers, tools, and technologies.
 \end{remark}
 
-\subsubsection{Tagged unions}
+\subsubsection{Final tagged union}
 
 Similar to variable-length arrays, a serialized representation of a tagged union consists of two segments:
 the implicit \emph{union tag} value followed by the selected field attribute value.
@@ -569,3 +572,7 @@ the serialized representation of the currently selected field attribute value\fo
         AnyType.1.0[<=1] maybe_some
     \end{minted}
 \end{remark}
+
+\subsubsection{Non-final}\label{sec:dsdl_serialization_composite_non_final}
+
+...

--- a/specification/dsdl/serialization.tex
+++ b/specification/dsdl/serialization.tex
@@ -604,7 +604,7 @@ The delimiter header, therefore, logically belongs to the container object rathe
 \end{remark}
 
 The delimiter header is an implicit field of type \verb|uint32| that encodes the length of the
-serialized representation it preceeds in bytes\footnote{%
+serialized representation it precedes in bytes\footnote{%
     Remember that by virtue of the padding requirement (section \ref{sec:dsdl_composite_alignment_cumulative_bls}),
     the length of the serialized representation of a composite type is always an integer number of bytes.
 }.

--- a/specification/dsdl/serialization.tex
+++ b/specification/dsdl/serialization.tex
@@ -579,16 +579,16 @@ the serialized representation of the currently selected field attribute value\fo
     \end{minted}
 \end{remark}
 
-\subsubsection{Non-final}\label{sec:dsdl_serialization_composite_non_final}
+\subsubsection{Delimited types}\label{sec:dsdl_serialization_composite_non_final}
 
-Objects of non-final composite types that are nested inside other objects\footnote{%
+Objects of delimited (non-final) composite types that are nested inside other objects\footnote{%
     Of any type, not necessarily composite; e.g., arrays.
 }
 are serialized into opaque containers that consist of two parts:
 the fixed-length \emph{delimiter header},
 immediately followed by the serialized representation of the object as if it was of a final type.
 
-Objects of non-final composite types that are \emph{not} nested inside other objects (i.e., top-level objects)
+Objects of delimited composite types that are \emph{not} nested inside other objects (i.e., top-level objects)
 are serialized as if they were of a final type (without the delimiter header).
 
 \begin{remark}
@@ -610,11 +610,11 @@ the implicit truncation (section \ref{sec:dsdl_serialization_implicit_truncation
 and the implicit zero extension (section \ref{sec:dsdl_serialization_implicit_zero_extension})
 rules apply.
 
-It is allowed for a final composite type to nest non-final composite types, and vice versa.
+It is allowed for a final composite type to nest delimited composite types, and vice versa.
 No special rules apply in such cases.
 
 \begin{remark}
-    The resulting serialized representation of a non-final composite is identical to \verb|uint8[<2**32]|.
+    The resulting serialized representation of a delimited composite is identical to \verb|uint8[<2**32]|.
     The implicit array length prefix here is like the delimiter header,
     and the array content is the serialized representation of the composite as if it was final.
 
@@ -670,7 +670,7 @@ No special rules apply in such cases.
             &\multicolumn{1}{c|}{$b_0$} & \multicolumn{1}{c|}{$b_1$}
             \\\cline{2-7}
         \end{tabular}
-        \caption{Extensibility of non-final types with the help of the delimiter header}
+        \caption{Extensibility of delimited types with the help of the delimiter header}
         \label{fig:dsdl_non_final_extensibility}
     \end{figure}
 
@@ -686,6 +686,6 @@ No special rules apply in such cases.
     There is an in-depth discussion of this issue (and other related matters) on the forum.
 
     The fixed-length delimiter header may be considered large,
-    but non-final types tend to also be complex, which makes the overhead comparatively insignificant,
+    but delimited types tend to also be complex, which makes the overhead comparatively insignificant,
     whereas final types that tend to be compact and overhead-sensitive do not contain the delimiter header.
 \end{remark}

--- a/specification/dsdl/serialization.tex
+++ b/specification/dsdl/serialization.tex
@@ -67,7 +67,7 @@ any excessive (unused) data or padding bits remaining upon deserialization\footn
 }.
 The total size of the serialized representation is reported either by the underlying transport layer, or,
 in the case of nested objects, by the \emph{delimiter header}
-(section \ref{sec:dsdl_serialization_composite_non_final}).
+(section \ref{sec:dsdl_serialization_composite_non_sealed}).
 
 As a consequence of the above requirement the transport layer can introduce
 additional zero padding bits at the end of a serialized representation
@@ -116,7 +116,7 @@ upon construction of a serialized representation of an object\footnote{%
 
 The total size of the serialized representation is reported either by the underlying transport layer, or,
 in the case of nested objects, by the \emph{delimiter header}
-(section \ref{sec:dsdl_serialization_composite_non_final}).
+(section \ref{sec:dsdl_serialization_composite_non_sealed}).
 
 \begin{remark}
     The implicit zero extension rule enables extension of data types by introducing additional fields
@@ -390,9 +390,9 @@ a fixed-length array of $n$ elements\footnote{%
 
 \subsection{Composite types}\label{sec:dsdl_serialization_composite}
 
-\subsubsection{Final structure}
+\subsubsection{Sealed structure}
 
-A serialized representation of an object of a final composite type that is not a tagged union
+A serialized representation of an object of a sealed composite type that is not a tagged union
 is a sequence of serialized representations of its field attribute values joined into a bit sequence,
 separated by padding if such is necessary to satisfy the alignment requirements.
 The ordering of the serialized representations of the field attribute values follows the order
@@ -409,7 +409,7 @@ of field attribute declaration.
         saturated  int4  third   #     -5                    1011   two's complement
         saturated  int2  fourth  #     -1                      11   two's complement
         truncated uint4  fifth   #   +136               1000_1000   overflow, MSB truncated
-        @final
+        @sealed
     \end{minted}
 
     It can be seen that the bit layout is rather complicated because the field boundaries do not align with byte
@@ -486,9 +486,9 @@ of field attribute declaration.
     not recommended because the convention is deeply ingrained in most readers, tools, and technologies.
 \end{remark}
 
-\subsubsection{Final tagged union}
+\subsubsection{Sealed tagged union}
 
-Similar to variable-length arrays, a serialized representation of a final tagged union consists of two segments:
+Similar to variable-length arrays, a serialized representation of a sealed tagged union consists of two segments:
 the implicit \emph{union tag} value followed by the selected field attribute value.
 
 The implicit union tag is an unsigned integer value whose serialized representation
@@ -525,7 +525,7 @@ the serialized representation of the currently selected field attribute value\fo
     Consider the following example:
 
     \begin{minted}{python}
-        @final
+        @sealed
         @union           # In this case, the implicit union tag is one byte wide
         uint16 FOO = 42  # A regular constant attribute
         uint16 a         # Field index 0
@@ -538,7 +538,7 @@ the serialized representation of the currently selected field attribute value\fo
     The following type will have an identical layout:
 
     \begin{minted}{python}
-        @final
+        @sealed
         uint8 implicit_union_tag  # Set to 1
         uint8 b                   # The actual value
     \end{minted}
@@ -562,13 +562,13 @@ the serialized representation of the currently selected field attribute value\fo
 
     \begin{minted}{python}
         # Empty. The only valid serialized representation is an empty bit sequence.
-        @final
+        @sealed
     \end{minted}
 
     Consider the following union:
 
     \begin{minted}{python}
-        @final
+        @sealed
         @union
         Empty.1.0 none
         AnyType.1.0 some
@@ -578,22 +578,22 @@ the serialized representation of the currently selected field attribute value\fo
     that of the following variable-length array:
 
     \begin{minted}{python}
-        @final
+        @sealed
         AnyType.1.0[<=1] maybe_some
     \end{minted}
 \end{remark}
 
-\subsubsection{Delimited types}\label{sec:dsdl_serialization_composite_non_final}
+\subsubsection{Delimited types}\label{sec:dsdl_serialization_composite_non_sealed}
 
-Objects of delimited (non-final) composite types that are nested inside other objects\footnote{%
+Objects of delimited (non-sealed) composite types that are nested inside other objects\footnote{%
     Of any type, not necessarily composite; e.g., arrays.
 }
 are serialized into opaque containers that consist of two parts:
 the fixed-length \emph{delimiter header},
-immediately followed by the serialized representation of the object as if it was of a final type.
+immediately followed by the serialized representation of the object as if it was of a sealed type.
 
 Objects of delimited composite types that are \emph{not} nested inside other objects (i.e., top-level objects)
-are serialized as if they were of a final type (without the delimiter header).
+are serialized as if they were of a sealed type (without the delimiter header).
 The delimiter header, therefore, logically belongs to the container object rather than the contained one.
 
 \begin{remark}
@@ -614,14 +614,14 @@ the implicit truncation (section \ref{sec:dsdl_serialization_implicit_truncation
 and the implicit zero extension (section \ref{sec:dsdl_serialization_implicit_zero_extension})
 rules apply.
 
-It is allowed for a final composite type to nest non-final composite types, and vice versa.
+It is allowed for a sealed composite type to nest non-sealed composite types, and vice versa.
 No special rules apply in such cases.
 
 \begin{remark}
     The resulting serialized representation of a delimited composite is identical to \verb|uint8[<2**32]|
     (sans the higher alignment requirement).
     The implicit array length field is like the delimiter header,
-    and the array content is the serialized representation of the composite as if it was final.
+    and the array content is the serialized representation of the composite as if it was sealed.
 
     The following illustrates why this is necessary for robust extensibility.
     Suppose that some composite $C$ contains two fields whose types are $A$ and $B$.
@@ -629,16 +629,16 @@ No special rules apply in such cases.
     likewise, $B$ contains $b_0,\ b_1$.
 
     Suppose that $C^\prime$ is modified such that $A^\prime$ contains an extra field $a_2$.
-    If $A$ (and $A^\prime$) were final, this would result in the breakage of compatibility between $C$ and $C^\prime$
-    as illustrated in figure \ref{fig:dsdl_final_non_extensibility} because the positions of the fields of $B$
-    (which is final) would be shifted by the size of $a_2$.
+    If $A$ (and $A^\prime$) were sealed, this would result in the breakage of compatibility between $C$ and $C^\prime$
+    as illustrated in figure \ref{fig:dsdl_sealed_non_extensibility} because the positions of the fields of $B$
+    (which is sealed) would be shifted by the size of $a_2$.
 
     The use of opaque containers allows the implicit truncation and the implicit zero extension rules to apply
     at any level of nesting, enabling agents expecting $C$ to truncate $a_2$ away,
     and enabling agents expecting $C^\prime$ to zero-extend $a_2$
-    if it is not present, as shown in figure \ref{fig:dsdl_non_final_extensibility},
+    if it is not present, as shown in figure \ref{fig:dsdl_non_sealed_extensibility},
     where $H_A$ is the delimiter header of $A$.
-    Observe that it is irrelevant whether $C$ (same as $C^\prime$) is final or not.
+    Observe that it is irrelevant whether $C$ (same as $C^\prime$) is sealed or not.
 
     \begin{figure}[H]
         \centering
@@ -655,8 +655,8 @@ No special rules apply in such cases.
             &\multicolumn{1}{c|}{$b_0$} & \multicolumn{1}{c|}{$b_1$}
             \\\cline{2-6}
         \end{tabular}
-        \caption{Non-extensibility of final types}
-        \label{fig:dsdl_final_non_extensibility}
+        \caption{Non-extensibility of sealed types}
+        \label{fig:dsdl_sealed_non_extensibility}
     \end{figure}
 
     \begin{figure}[H]
@@ -677,12 +677,12 @@ No special rules apply in such cases.
             \\\cline{2-7}
         \end{tabular}
         \caption{Extensibility of delimited types with the help of the delimiter header}
-        \label{fig:dsdl_non_final_extensibility}
+        \label{fig:dsdl_non_sealed_extensibility}
     \end{figure}
 
     The design decision to make the delimiter header of a fixed width may not be obvious so it's worth explaining.
     There are two alternatives: making it variable-length and making the length a function of the extent
-    (section \ref{sec:dsdl_composite_extent_and_finality}).
+    (section \ref{sec:dsdl_composite_extent_and_sealing}).
     The first option does not align with the rest of the specification because DSDL does not make use of
     variable-length integers (unlike some other formats, like Google Protobuf, for example),
     and because a variable-length length {\footnotesize{(sic!)}} prefix would have somewhat complicated the
@@ -694,7 +694,7 @@ No special rules apply in such cases.
 
     The fixed-length delimiter header may be considered large,
     but delimited types tend to also be complex, which makes the overhead comparatively insignificant,
-    whereas final types that tend to be compact and overhead-sensitive do not contain the delimiter header.
+    whereas sealed types that tend to be compact and overhead-sensitive do not contain the delimiter header.
 \end{remark}
 
 \begin{remark}

--- a/specification/dsdl/serialization.tex
+++ b/specification/dsdl/serialization.tex
@@ -94,7 +94,7 @@ Non-zero padding bits are not allowed\footnote{%
     The topic of data type compatibility is explored in detail in section~\ref{sec:dsdl_versioning}.
 \end{remark}
 
-\subsubsection{Implicit zero extension of missing data}
+\subsubsection{Implicit zero extension of missing data}\label{sec:dsdl_serialization_implicit_zero_extension}
 
 For the purposes of deserialization routines,
 the serialized representation of any instance of a data type shall \emph{implicitly} end with an
@@ -406,6 +406,7 @@ of field attribute declaration.
         saturated  int4  third   #     -5                    1011   two's complement
         saturated  int2  fourth  #     -1                      11   two's complement
         truncated uint4  fifth   #   +136               1000_1000   overflow, MSB truncated
+        @final
     \end{minted}
 
     It can be seen that the bit layout is rather complicated because the field boundaries do not align with byte
@@ -484,7 +485,7 @@ of field attribute declaration.
 
 \subsubsection{Final tagged union}
 
-Similar to variable-length arrays, a serialized representation of a tagged union consists of two segments:
+Similar to variable-length arrays, a serialized representation of a final tagged union consists of two segments:
 the implicit \emph{union tag} value followed by the selected field attribute value.
 
 The implicit union tag is an unsigned integer value whose serialized representation
@@ -520,6 +521,7 @@ the serialized representation of the currently selected field attribute value\fo
     Consider the following example:
 
     \begin{minted}{python}
+        @final
         @union           # In this case, the implicit union tag is one byte wide
         uint16 FOO = 42  # A regular constant attribute
         uint16 a         # Field index 0
@@ -532,6 +534,7 @@ the serialized representation of the currently selected field attribute value\fo
     The following data schema will have an identical layout:
 
     \begin{minted}{python}
+        @final
         uint8 implicit_union_tag  # Set to 1
         uint8 b                   # The actual value
     \end{minted}
@@ -555,11 +558,13 @@ the serialized representation of the currently selected field attribute value\fo
 
     \begin{minted}{python}
         # Empty. The only valid serialized representation is an empty bit sequence.
+        @final
     \end{minted}
 
     Consider the following union schema definition:
 
     \begin{minted}{python}
+        @final
         @union
         Empty.1.0 none
         AnyType.1.0 some
@@ -569,10 +574,118 @@ the serialized representation of the currently selected field attribute value\fo
     that of the following variable-length array:
 
     \begin{minted}{python}
+        @final
         AnyType.1.0[<=1] maybe_some
     \end{minted}
 \end{remark}
 
 \subsubsection{Non-final}\label{sec:dsdl_serialization_composite_non_final}
 
-...
+Objects of non-final composite types that are nested inside other objects\footnote{%
+    Of any type, not necessarily composite; e.g., arrays.
+}
+are serialized into opaque containers that consist of two parts:
+the fixed-length \emph{delimiter header},
+immediately followed by the serialized representation of the object as if it was of a final type.
+
+Objects of non-final composite types that are \emph{not} nested inside other objects (i.e., top-level objects)
+are serialized as if they were of a final type (without the delimiter header).
+
+\begin{remark}
+    Top-level objects do not require the delimiter header because the change in their length does not necessarily
+    affect the backward compatibility thanks to the implicit truncation rule
+    (section \ref{sec:dsdl_serialization_implicit_truncation}) and the implicit zero extension rule
+    (section \ref{sec:dsdl_serialization_implicit_zero_extension}).
+    The delimiter header, therefore, logically belongs to the container object rather than the contained one.
+\end{remark}
+
+The delimiter header is an implicit field of type \verb|uint32| that encodes the length of the following
+serialized representation in bytes\footnote{%
+    Remember that by virtue of the padding requirement (section \ref{sec:dsdl_composite_alignment_cumulative_bls}),
+    the length of the serialized representation of a composite type is always an integer number of bytes.
+}.
+During deserialization, if the length of the serialized representation reported by its delimiter header
+does not match the expectation of the deserializer,
+the implicit truncation (section \ref{sec:dsdl_serialization_implicit_truncation})
+and the implicit zero extension (section \ref{sec:dsdl_serialization_implicit_zero_extension})
+rules apply.
+
+It is allowed for a final composite type to nest non-final composite types, and vice versa.
+No special rules apply in such cases.
+
+\begin{remark}
+    The resulting serialized representation of a non-final composite is identical to \verb|uint8[<2**32]|.
+    The implicit array length prefix here is like the delimiter header,
+    and the array content is the serialized representation of the composite as if it was final.
+
+    The following illustrates why this is necessary for robust extensibility.
+    Suppose that some composite $C$ contains two fields whose types are $A$ and $B$.
+    The fields of $A$ are $a_0,\ a_1$;
+    likewise, $B$ contains $b_0,\ b_1$.
+
+    Suppose that $C^\prime$ is modified such that $A^\prime$ contains an extra field $a_2$.
+    If $A$ (and $A^\prime$) were final, this would result in the breakage of compatibility between $C$ and $C^\prime$
+    as illustrated in figure \ref{fig:dsdl_final_non_extensibility} because the positions of the fields of $B$
+    (which is final) would be shifted by the size of $a_2$.
+
+    The use of opaque containers allows the implicit truncation and the implicit zero extension rules to apply
+    at any level of nesting, enabling agents expecting $C$ to truncate $a_2$ away,
+    and enabling agents expecting $C^\prime$ to zero-extend $a_2$
+    if it is not present, as shown in figure \ref{fig:dsdl_non_final_extensibility},
+    where $H_A$ is the delimiter header of $A$.
+    Observe that it is irrelevant whether $C$ (same as $C^\prime$) is final or not.
+
+    \begin{figure}[H]
+        \centering
+        \begin{tabular}{r c c c c c}
+            \cline{2-5}
+            $C$ &
+            \multicolumn{1}{|c|}{$a_0$} & \multicolumn{1}{c|}{$a_1$}
+            &\multicolumn{1}{c|}{$b_0$} & \multicolumn{1}{c|}{$b_1$} &
+            \\\cline{2-5}
+            & $\checkmark$ & $\checkmark$ & $\times$ & $\times$ & $\times$ \\
+            \cline{2-6}
+            $C^\prime$ &
+            \multicolumn{1}{|c|}{$a_0$} & \multicolumn{1}{c|}{$a_1$} & \multicolumn{1}{c|}{$a_2$}
+            &\multicolumn{1}{c|}{$b_0$} & \multicolumn{1}{c|}{$b_1$}
+            \\\cline{2-6}
+        \end{tabular}
+        \caption{Non-extensibility of final types}
+        \label{fig:dsdl_final_non_extensibility}
+    \end{figure}
+
+    \begin{figure}[H]
+        \centering
+        \begin{tabular}{r c c c c c c}
+            \cline{2-7}
+            $C$ &
+            \multicolumn{1}{|c|}{$H_A$} & \multicolumn{1}{c|}{$a_0$} & \multicolumn{1}{c|}{$a_1$}
+            &\multicolumn{1}{c|}{\footnotesize{$\ldots$}}
+            &\multicolumn{1}{c|}{$b_0$} & \multicolumn{1}{c|}{$b_1$}
+            \\\cline{2-7}
+            & $\checkmark$ & $\checkmark$ & $\checkmark$ & $\checkmark$ & $\checkmark$ & $\checkmark$ \\
+            \cline{2-7}
+            $C^\prime$ &
+            \multicolumn{1}{|c|}{$H_A$} & \multicolumn{1}{c|}{$a_0$} & \multicolumn{1}{c|}{$a_1$} & \multicolumn{1}{c|}{$a_2$}
+            &\multicolumn{1}{c|}{$b_0$} & \multicolumn{1}{c|}{$b_1$}
+            \\\cline{2-7}
+        \end{tabular}
+        \caption{Extensibility of non-final types with the help of the delimiter header}
+        \label{fig:dsdl_non_final_extensibility}
+    \end{figure}
+
+    The design decision to make the delimiter header of a fixed width may not be obvious so it's worth explaining.
+    There are two alternatives: making it variable-length and making the length a function of the extent
+    (section \ref{sec:dsdl_composite_extent_and_finality}).
+    The first option does not align with the rest of the specification because DSDL does not make use of
+    variable-length integers (unlike some other formats, like Google Protobuf, for example),
+    and because a variable-length length prefix would have somewhat complicated the bit length set computation.
+    The second option would make nested hierarchies (composites that nest other composites) possibly highly fragile
+    because the change of the extent of a deeply nested type may inadvertently move the delimiter header of an
+    outer type into a different length category, which would be disastrous for compatibility and hard to spot.
+    There is an in-depth discussion of this issue (and other related matters) on the forum.
+
+    The fixed-length delimiter header may be considered large,
+    but non-final types tend to also be complex, which makes the overhead comparatively insignificant,
+    whereas final types that tend to be compact and overhead-sensitive do not contain the delimiter header.
+\end{remark}

--- a/specification/dsdl/serialization.tex
+++ b/specification/dsdl/serialization.tex
@@ -65,6 +65,9 @@ When a serialized representation is deserialized, implementations shall ignore
 any excessive (unused) data or padding bits remaining upon deserialization\footnote{%
     The presence of unused data should not be considered an error.
 }.
+The total size of the serialized representation is reported either by the underlying transport layer, or,
+in the case of nested objects, by the \emph{delimiter header}
+(section \ref{sec:dsdl_serialization_composite_non_final}).
 
 As a consequence of the above requirement the transport layer can introduce
 additional zero padding bits at the end of a serialized representation
@@ -111,6 +114,10 @@ upon construction of a serialized representation of an object\footnote{%
     If intentional truncation were allowed, removal of this rule would break backward compatibility.
 }.
 
+The total size of the serialized representation is reported either by the underlying transport layer, or,
+in the case of nested objects, by the \emph{delimiter header}
+(section \ref{sec:dsdl_serialization_composite_non_final}).
+
 \begin{remark}
     The implicit zero extension rule enables extension of data types by introducing additional fields
     without breaking backward compatibility with existing deployments.
@@ -151,7 +158,7 @@ Correct UAVCAN types shall have no other deserialization error states.
 The serialized representation of a void-typed field attribute is constructed as a sequence of zero bits.
 The length of the sequence equals the numeric suffix of the type name.
 
-When a void-typed field attribute is decoded, the values of respective bits are ignored;
+When a void-typed field attribute is deserialized, the values of respective bits are ignored;
 in other words, any bit sequence of correct length is a valid serialized representation
 of a void-typed field attribute.
 This behavior facilitates usage of void fields as placeholders for non-void fields
@@ -318,7 +325,7 @@ a sequence of $n$ field attributes of type $T$ are equivalent.
 \subsubsection{Variable-length array types}\label{sec:dsdl_serialized_variable_length_array}
 
 A serialized representation of a variable-length array consists of two segments:
-the implicit length field followed by the array elements.
+the implicit length field immediately followed by the array elements.
 
 The implicit length field is of an unsigned integer type.
 The serialized representation of the implicit length field
@@ -345,6 +352,7 @@ The rest of the serialized representation is constructed as if the variable-leng
 a fixed-length array of $n$ elements\footnote{%
     Observe that the implicit array length field, per its definition,
     is guaranteed to never break the alignment of the following array elements.
+    There may be no padding between the implicit array length field and its elements.
 }.
 
 \begin{remark}
@@ -510,6 +518,7 @@ The serialized representation of the implicit union tag is immediately followed 
 the serialized representation of the currently selected field attribute value\footnote{%
     Observe that the implicit union tag field, per its definition,
     is guaranteed to never break the alignment of the following field.
+    There may be no padding between the implicit union tag field and the selected field.
 }.
 
 \begin{remark}
@@ -525,7 +534,7 @@ the serialized representation of the currently selected field attribute value\fo
         float64 c        # Field index 2
     \end{minted}
 
-    In order to encode the field \verb|b|, the implicit union tag shall be assigned the value 1.
+    In order to serialize the field \verb|b|, the implicit union tag shall be assigned the value 1.
     The following type will have an identical layout:
 
     \begin{minted}{python}
@@ -585,13 +594,13 @@ immediately followed by the serialized representation of the object as if it was
 
 Objects of delimited composite types that are \emph{not} nested inside other objects (i.e., top-level objects)
 are serialized as if they were of a final type (without the delimiter header).
+The delimiter header, therefore, logically belongs to the container object rather than the contained one.
 
 \begin{remark}
     Top-level objects do not require the delimiter header because the change in their length does not necessarily
     affect the backward compatibility thanks to the implicit truncation rule
     (section \ref{sec:dsdl_serialization_implicit_truncation}) and the implicit zero extension rule
     (section \ref{sec:dsdl_serialization_implicit_zero_extension}).
-    The delimiter header, therefore, logically belongs to the container object rather than the contained one.
 \end{remark}
 
 The delimiter header is an implicit field of type \verb|uint32| that encodes the length of the following
@@ -605,11 +614,12 @@ the implicit truncation (section \ref{sec:dsdl_serialization_implicit_truncation
 and the implicit zero extension (section \ref{sec:dsdl_serialization_implicit_zero_extension})
 rules apply.
 
-It is allowed for a final composite type to nest delimited composite types, and vice versa.
+It is allowed for a final composite type to nest non-final composite types, and vice versa.
 No special rules apply in such cases.
 
 \begin{remark}
-    The resulting serialized representation of a delimited composite is identical to \verb|uint8[<2**32]|.
+    The resulting serialized representation of a delimited composite is identical to \verb|uint8[<2**32]|
+    (sans the higher alignment requirement).
     The implicit array length prefix here is like the delimiter header,
     and the array content is the serialized representation of the composite as if it was final.
 
@@ -675,7 +685,8 @@ No special rules apply in such cases.
     (section \ref{sec:dsdl_composite_extent_and_finality}).
     The first option does not align with the rest of the specification because DSDL does not make use of
     variable-length integers (unlike some other formats, like Google Protobuf, for example),
-    and because a variable-length length prefix would have somewhat complicated the bit length set computation.
+    and because a variable-length length {\footnotesize{(sic!)}} prefix would have somewhat complicated the
+    bit length set computation.
     The second option would make nested hierarchies (composites that nest other composites) possibly highly fragile
     because the change of the extent of a deeply nested type may inadvertently move the delimiter header of an
     outer type into a different length category, which would be disastrous for compatibility and hard to spot.
@@ -684,4 +695,33 @@ No special rules apply in such cases.
     The fixed-length delimiter header may be considered large,
     but delimited types tend to also be complex, which makes the overhead comparatively insignificant,
     whereas final types that tend to be compact and overhead-sensitive do not contain the delimiter header.
+\end{remark}
+
+\begin{remark}
+    In order to efficiently serialize an object of a delimited type,
+    the implementation may need to perform a second pass to reach the delimiter header
+    after the object is serialized, because before that, the value of the delimiter header cannot be known
+    unless the object is of a fixed-size (i.e., the cardinality of the bit length set is one).
+
+    Consider:
+    \begin{minted}{python}
+        uint8[<=4] x
+    \end{minted}
+    Let $\texttt{x} = \left[ 4, 2 \right]$,
+    then the nested serialized representation would be constructed as:
+    \begin{enumerate}
+        \item Memorize the current memory address $M_\text{origin}$.
+        \item Skip 32 bits.
+        \item Encode the length: 2 elements.
+        \item Encode $x_0 = 4$.
+        \item Encode $x_1 = 2$.
+        \item Memorize the current memory address $M_\text{current}$.
+        \item Go back to $M_\text{origin}$.
+        \item Encode a 32-bit wide value of $(M_\text{current} - M_\text{origin})$.
+        \item Go back to $M_\text{current}$.
+    \end{enumerate}
+
+    However, if the object is known to be of a constant size, the above can be simplified,
+    because there may be only one possible value of the delimiter header.
+    Automatic code generation tools should take advantage of this knowledge for best result.
 \end{remark}

--- a/specification/dsdl/serialization.tex
+++ b/specification/dsdl/serialization.tex
@@ -680,6 +680,14 @@ No special rules apply in such cases.
         \label{fig:dsdl_non_sealed_extensibility}
     \end{figure}
 
+    This example also illustrates why the extent is necessary.
+    Per the rules set forth in \ref{sec:dsdl_composite_extent_and_sealing},
+    it is required that the extent (i.e., the buffer memory requirement) of $A$ shall be large enough to accommodate
+    serialized representations of $A^\prime$, and, therefore,
+    the extent of $C$ is large enough to accommodate serialized representations of $C^\prime$.
+    If that were not the case, then an implementation expecting $C$ would be unable to correctly process $C^\prime$
+    because the implicit truncation rule would have cut off $b_1$, which is unexpected.
+
     The design decision to make the delimiter header of a fixed width may not be obvious so it's worth explaining.
     There are two alternatives: making it variable-length and making the length a function of the extent
     (section \ref{sec:dsdl_composite_extent_and_sealing}).

--- a/specification/dsdl/serialization.tex
+++ b/specification/dsdl/serialization.tex
@@ -603,8 +603,8 @@ The delimiter header, therefore, logically belongs to the container object rathe
     (section \ref{sec:dsdl_serialization_implicit_zero_extension}).
 \end{remark}
 
-The delimiter header is an implicit field of type \verb|uint32| that encodes the length of the following
-serialized representation in bytes\footnote{%
+The delimiter header is an implicit field of type \verb|uint32| that encodes the length of the
+serialized representation it preceeds in bytes\footnote{%
     Remember that by virtue of the padding requirement (section \ref{sec:dsdl_composite_alignment_cumulative_bls}),
     the length of the serialized representation of a composite type is always an integer number of bytes.
 }.

--- a/specification/dsdl/serialization.tex
+++ b/specification/dsdl/serialization.tex
@@ -59,33 +59,10 @@ such format is also known as little-endian.
     \caption{Bit and byte ordering\label{fig:dsdl_serialization_bit_ordering}}
 \end{figure}
 
-\subsubsection{Implicit padding}
-
-Excepting one edge case reviewed below,
-serialized representations of DSDL entities never include implicit data padding.
-Unaligned data may lead to suboptimal serialization and deserialization performance;
-therefore, the data type designer should manually align elements as necessary to prevent performance degradation.
-It is guaranteed, however, that unaligned data cannot result in unspecified or otherwise unexpected behavior
-of the data handling routines.
-The manual approach to data alignment allows the data type designer to trade-off serialization efficiency
-over network bandwidth utilization and data transfer latency as necessary without compromising functional safety.
-
-The exceptional edge case mentioned above when implicit padding is introduced is as follows.
-Serialized representations of DSDL entities operate at the bit level,
-whereas the transport protocols supported by UAVCAN\footnote{As well as the majority of network protocols in general.}
-use bytes as the smallest atomic data element.
-The resulting mismatch of the data granularity levels is resolved by
-appending the serialized representation of the top-level composite type object with zero (0) bits
-until the length of its bit sequence is an integer multiple of eight (8).
-The term \emph{top-level object} denotes an object that is not nested inside another DSDL entity.
-In other words, padding bits may only be added before a fully constructed serialized representation is
-handed over for transmission over the UAVCAN network
-(or any other destination which does not support bit-level data granularity).
-
-\subsubsection{Implicit truncation of excessive data}
+\subsubsection{Implicit truncation of excessive data}\label{sec:dsdl_serialization_implicit_truncation}
 
 When a serialized representation is deserialized, implementations shall ignore
-any excessive (unused) data remaining upon deserialization\footnote{%
+any excessive (unused) data or padding bits remaining upon deserialization\footnote{%
     The presence of unused data should not be considered an error.
 }.
 
@@ -365,11 +342,15 @@ By definition, $n \leq c$; therefore, bit sequences where the implicit length fi
 greater than $c$ do not belong to the set of serialized representations of the array.
 
 The rest of the serialized representation is constructed as if the variable-length array was
-a fixed-length array of $n$ elements.
+a fixed-length array of $n$ elements\footnote{%
+    Observe that the implicit array length field, per its definition,
+    is guaranteed to never break the alignment of the following array elements.
+}.
 
 \begin{remark}
-    Datatype authors must take into account that dynamic arrays with a capacity of $\leq{}255$ elements will
-    consume an additional 8-bits of the serialized representation (where a capacity of $\leq 65535$ will consume 16-bits and so on).
+    Data type authors must take into account that variable-length arrays with a capacity of $\leq{}255$ elements will
+    consume an additional 8 bits of the serialized representation
+    (where a capacity of $\leq 65535$ will consume 16 bits and so on).
     For example:
 
     \begin{minted}{python}
@@ -527,7 +508,10 @@ therefore, bit sequences where the implicit union tag field contains values
 that are greater than or equal $n$ do not belong to the set of serialized representations of the tagged union.
 
 The serialized representation of the implicit union tag is immediately followed by
-the serialized representation of the currently selected field attribute value.
+the serialized representation of the currently selected field attribute value\footnote{%
+    Observe that the implicit union tag field, per its definition,
+    is guaranteed to never break the alignment of the following field.
+}.
 
 \begin{remark}
     Consider the following example:

--- a/specification/dsdl/serialization.tex
+++ b/specification/dsdl/serialization.tex
@@ -723,5 +723,5 @@ No special rules apply in such cases.
 
     However, if the object is known to be of a constant size, the above can be simplified,
     because there may be only one possible value of the delimiter header.
-    Automatic code generation tools should take advantage of this knowledge for best result.
+    Automatic code generation tools should take advantage of this knowledge.
 \end{remark}

--- a/specification/dsdl/serialization.tex
+++ b/specification/dsdl/serialization.tex
@@ -620,7 +620,7 @@ No special rules apply in such cases.
 \begin{remark}
     The resulting serialized representation of a delimited composite is identical to \verb|uint8[<2**32]|
     (sans the higher alignment requirement).
-    The implicit array length prefix here is like the delimiter header,
+    The implicit array length field is like the delimiter header,
     and the array content is the serialized representation of the composite as if it was final.
 
     The following illustrates why this is necessary for robust extensibility.

--- a/specification/introduction/introduction.tex
+++ b/specification/introduction/introduction.tex
@@ -211,9 +211,15 @@ in one of the standard bodies.
 Compared to v1.0-alpha, the differences are as follows (the motivation is provided on the forum):
 
 \begin{itemize}
+    \item The physical layer specification has been removed.
+          It is now up to the domain-specific UAVCAN-based standards to define the physical layer.
+
     \item The subject-ID range reduced from $[0, 32767]$ down to $[0, 8191]$.
+          This change may be reverted in a future edition of the standard, if found practical.
+
     \item Added support for delimited serialization; introduced related concepts of \emph{extent} and \emph{finality}
           (section \ref{sec:dsdl_composite_extent_and_finality}).
+          This change enables one to easily evolve networked services in a backward-compatible way.
 \end{itemize}
 
 \subsection{v1.0-alpha -- Jan 2020}

--- a/specification/introduction/introduction.tex
+++ b/specification/introduction/introduction.tex
@@ -215,6 +215,3 @@ Compared to v1.0-alpha, the differences are as follows (the motivation is provid
 
 This is the initial version of the document.
 The discussions that shaped the initial version are available on the public UAVCAN discussion forum.
-
-%\subsection{v1.0}
-% Hello world!

--- a/specification/introduction/introduction.tex
+++ b/specification/introduction/introduction.tex
@@ -21,7 +21,10 @@ UAVCAN is a standard open to everyone, and it will always remain this way.
 No authorization or approval of any kind is necessary for its implementation, distribution, or use.
 
 The development and maintenance of the UAVCAN specification is governed through the public discussion forum,
-software repositories, and other resources available via the website at \href{http://uavcan.org}{uavcan.org}.
+software repositories, and other resources available via the official website at \href{http://uavcan.org}{uavcan.org}.
+
+Engineers seeking to leverage UAVCAN should also consult with \emph{The UAVCAN Guide} --
+a separate textbook available via the official website.
 
 \section{Document conventions}
 

--- a/specification/introduction/introduction.tex
+++ b/specification/introduction/introduction.tex
@@ -209,6 +209,7 @@ Compared to v1.0-alpha, the differences are as follows (the motivation is provid
 
 \begin{itemize}
     \item The subject-ID range reduced from $[0, 32767]$ down to $[0, 8191]$.
+    \item Added support for delimited serialization; introduced related concepts of \emph{extent} and \emph{finality}.
 \end{itemize}
 
 \subsection{v1.0-alpha -- Jan 2020}

--- a/specification/introduction/introduction.tex
+++ b/specification/introduction/introduction.tex
@@ -212,7 +212,8 @@ Compared to v1.0-alpha, the differences are as follows (the motivation is provid
 
 \begin{itemize}
     \item The subject-ID range reduced from $[0, 32767]$ down to $[0, 8191]$.
-    \item Added support for delimited serialization; introduced related concepts of \emph{extent} and \emph{finality}.
+    \item Added support for delimited serialization; introduced related concepts of \emph{extent} and \emph{finality}
+          (section \ref{sec:dsdl_composite_extent_and_finality}).
 \end{itemize}
 
 \subsection{v1.0-alpha -- Jan 2020}

--- a/specification/introduction/introduction.tex
+++ b/specification/introduction/introduction.tex
@@ -218,8 +218,8 @@ Compared to v1.0-alpha, the differences are as follows (the motivation is provid
     \item The subject-ID range reduced from $[0, 32767]$ down to $[0, 8191]$.
           This change may be reverted in a future edition of the standard, if found practical.
 
-    \item Added support for delimited serialization; introduced related concepts of \emph{extent} and \emph{finality}
-          (section \ref{sec:dsdl_composite_extent_and_finality}).
+    \item Added support for delimited serialization; introduced related concepts of \emph{extent} and \emph{sealing}
+          (section \ref{sec:dsdl_composite_extent_and_sealing}).
           This change enables one to easily evolve networked services in a backward-compatible way.
 \end{itemize}
 

--- a/specification/sdt/sdt.tex
+++ b/specification/sdt/sdt.tex
@@ -10,7 +10,7 @@ Regulated non-standard definitions\footnote{%
 } are not included in this list.
 
 In the table, \emph{BLS} stands for bit length set.
-The extent is not shown for final entities -- that would be redundant because finality implies
+The extent is not shown for sealed entities -- that would be redundant because sealing implies
 that the extent equals the maximum bit length set.
 For service types, the parameters pertaining to the request and response are shown separately.
 

--- a/specification/sdt/sdt.tex
+++ b/specification/sdt/sdt.tex
@@ -12,7 +12,7 @@ Regulated non-standard definitions\footnote{%
 In the table, \emph{BLS} stands for bit length set.
 The extent is not shown for final entities -- that would be redundant because finality implies
 that the extent equals the maximum bit length set.
-For service types, the parameters pertaining to the request and response schemas are shown separately.
+For service types, the parameters pertaining to the request and response are shown separately.
 
 The index table~\ref{table:dsdl:uavcan} is provided before the definitions for ease of navigation.
 

--- a/specification/sdt/sdt.tex
+++ b/specification/sdt/sdt.tex
@@ -9,12 +9,10 @@ Regulated non-standard definitions\footnote{%
     of the specification, as explained in section~\ref{sec:basic_data_type_regulation}.
 } are not included in this list.
 
-Each definition is provided with a length information table for convenience,
-where the minimum and maximum serialized length is shown in several units:
-bits, bytes (octets), and transport frames for some of the supported transport protocols.
-The acronym \emph{MTU} used in the length information tables stands for
-\emph{maximum transmission unit}, which is the maximum amount of data, in bytes (octets, eight bits per byte),
-that fits into one transport frame for the specific transport protocol.
+In the table, \emph{BLS} stands for bit length set.
+The extent is not shown for final entities -- that would be redundant because finality implies
+that the extent equals the maximum bit length set.
+For service types, the parameters pertaining to the request and response schemas are shown separately.
 
 The index table~\ref{table:dsdl:uavcan} is provided before the definitions for ease of navigation.
 


### PR DESCRIPTION
Fixes https://github.com/UAVCAN/specification/issues/90

Context, motivation, discussion: https://forum.uavcan.org/t/data-type-extensibility-and-composition/827

Implementation: https://github.com/UAVCAN/pydsdl/pull/45; its documentation: https://pydsdl--45.org.readthedocs.build/en/45/

-----

This is the last PR separating us from v1.0-beta; you will notice that I have renamed the document into "**Specification v1.0-beta**" in this branch already.

The changeset is large because it required updating many independent sections of the document. I recommend reviewing it by simply reading chapter **3 DSDL**, without any regard for the diffs. Afterward, the second pass can be done by looking at the diffs only.

There are some inconsequential changes in the script `render_dsdl.py` that are safe to ignore. This script is seriously getting out of hand and I wish someone could rewrite it using a proper template engine like Jinja. I never expected it to grow so complex.

I also removed the term "data schema" from the spec because it did not reflect the reality accurately and was used incorrectly in several places. Instead, we now use "data type". This change made it painfully obvious that service types should not even belong in the category of serializable types because they are not serializable, but I suppose we'll not be changing this detail now unless someone is willing to volunteer.