### PR TITLE
Remove default extent

### DIFF
--- a/specification/dsdl/compatibility.tex
+++ b/specification/dsdl/compatibility.tex
@@ -19,6 +19,7 @@ The property of semantic compatibility is commutative.
         uint16 FLAG_A = 1
         uint16 FLAG_B = 256
         uint16 flags
+        @extent 16
     \end{minted}
 
     \begin{minted}{python}
@@ -26,6 +27,7 @@ The property of semantic compatibility is commutative.
         uint8 FLAG_B = 1
         uint8 flags_a
         uint8 flags_b
+        @extent 16
     \end{minted}
 
     It should be noted here that due to different set of field and constant attributes,
@@ -39,6 +41,7 @@ The property of semantic compatibility is commutative.
     \begin{minted}{python}
         uint8 FLAG_A = 1
         uint8 flags_a
+        @extent 16
     \end{minted}
 \end{remark}
 
@@ -48,6 +51,7 @@ The property of semantic compatibility is commutative.
     \begin{minted}{python}
         float32 foo
         float64 bar
+        @extent 128
     \end{minted}
 
     Let node $B$ subscribe to the same subject using the following data type definition:
@@ -56,6 +60,7 @@ The property of semantic compatibility is commutative.
         float32 foo
         float64 bar
         int16   baz  # Extra field; implicit zero extension rule applies.
+        @extent 128
     \end{minted}
 
     Let node $C$ subscribe to the same subject using the following data type definition:
@@ -63,6 +68,7 @@ The property of semantic compatibility is commutative.
     \begin{minted}{python}
         float32 foo
         # The field 'bar' is missing; implicit truncation rule applies.
+        @extent 128
     \end{minted}
 
     Provided that the semantics of the added and omitted fields allow it,
@@ -155,14 +161,6 @@ It is therefore advised to:
     without compromising the temporal properties of the system.
 \end{itemize}
 
-\begin{remark}
-    Suppose that there is a new data type v1.0.
-    Then, v1.1 is released whose bit length set is different (for example, a field was added or removed).
-    To keep the extent compatible with v1.0,
-    the author of v1.1 should now set it explicitly using the \verb|@extent| directive.
-    It may be preferred to set the extent manually starting with v1.0 for clarity.
-\end{remark}
-
 \subsubsection{Fixed port identifier assignment constraints}
 
 The following constraints apply to fixed port-ID assignments:
@@ -224,6 +222,8 @@ The minor versions may differ, which is acceptable due to the major version comp
         uint8 FLAG_CRYOBOX_BREACH  = 128
         # Error flags in the higher bits.
         uint8 flags  # Storage for the above defined flags (this is not the recommended practice).
+
+        @extent 1024 * 8  # Pick a large extent to allow evolution. Does not affect network traffic.
     \end{minted}
 
     The definition is then deployed to the first prototype for initial laboratory testing.
@@ -256,6 +256,8 @@ The minor versions may differ, which is acceptable due to the major version comp
         uint8 FLAG_CRYOBOX_BREACH  = 128
         # Error flags in the higher bits.
         uint8 flags  # Storage for the above defined flags (this is not the recommended practice).
+
+        @extent 512 * 8  # Extent can be changed freely because v0.x does not guarantee compatibility.
     \end{minted}
 
     The last definition is deemed sufficient and is deployed to the production system
@@ -285,6 +287,8 @@ The minor versions may differ, which is acceptable due to the major version comp
         bool flag_overheating
         bool flag_cryobox_breach
         # Error flags (this is the recommended practice).
+
+        @extent 512 * 8  # Extent is to be kept unchanged now to avoid breaking compatibility.
     \end{minted}
 
     Since the definitions v1.0 and v1.1 are semantically compatible,
@@ -310,6 +314,8 @@ The minor versions may differ, which is acceptable due to the major version comp
         bool flag_psu_malfunction
         bool flag_overheating
         bool flag_cryobox_breach
+
+        @extent 768 * 8  # Since the major version number is different, extent can be changed.
     \end{minted}
 
     Imagine that later it was determined that the module should report additional status information
@@ -340,7 +346,7 @@ The minor versions may differ, which is acceptable due to the major version comp
         # Coolant pump fields (extension over v2.0; implicit truncation/extension rules apply)
         # If zero, assume that the values are unavailable.
 
-        @extent 32*8  # Set the extent manually so that it is the same as in the previous version v2.0.
+        @extent 768 * 8
     \end{minted}
 
     It is also possible to add an optional field at the end wrapped into a variable-length

--- a/specification/dsdl/compatibility.tex
+++ b/specification/dsdl/compatibility.tex
@@ -110,7 +110,7 @@ When a new data type is first released,
 the version numbers of its first definition shall be assigned ``1.0'' (major 1, minor 0).
 
 In order to ensure predictability and functional safety of applications that leverage UAVCAN,
-it is required that once a data type definition is released,
+it is recommended that once a data type definition is released,
 its DSDL source text, name, version numbers, fixed port-ID, extent, sealing, and other properties cannot undergo any
 modifications whatsoever, with the following exceptions:
 \begin{itemize}

--- a/specification/dsdl/directives.tex
+++ b/specification/dsdl/directives.tex
@@ -35,11 +35,12 @@ Usage of this directive is subject to the following constraints:
     \end{minted}
 \end{remark}
 
-\subsection{Explicit extent specifier}\label{sec:dsdl_directive_extent}
+\subsection{Extent specifier}\label{sec:dsdl_directive_extent}
 
-The identifier of the explicit extent specification directive is ``\verb|extent|''.
-This directive overrides the default extent of its data type (section \ref{sec:dsdl_composite_extent_and_sealing})
-with the value obtained by evaluating the provided expression.
+The identifier of the extent specification directive is ``\verb|extent|''.
+This directive declares the current data type definition to be delimited (non-sealed)
+and specifies its extent (section \ref{sec:dsdl_composite_extent_and_sealing}).
+The extent value is obtained by evaluating the provided expression.
 The expression shall be present and it shall yield a non-negative integer value of type
 ``\verb|rational|'' (section~\ref{sec:dsdl_primitive_types}) upon its evaluation.
 
@@ -72,8 +73,7 @@ Usage of this directive is subject to the following constraints (otherwise, the 
 \subsection{Sealing marker}\label{sec:dsdl_directive_sealed}
 
 The identifier of the sealing marker directive is ``\verb|sealed|''.
-This directive marks the current data type sealed (section \ref{sec:dsdl_composite_extent_and_sealing})
-(if not provided, the data type is non-sealed).
+This directive marks the current data type sealed (section \ref{sec:dsdl_composite_extent_and_sealing}).
 
 Usage of this directive is subject to the following constraints (otherwise, the definition is malformed):
 \begin{itemize}

--- a/specification/dsdl/serializable_types.tex
+++ b/specification/dsdl/serializable_types.tex
@@ -402,15 +402,6 @@ The related mechanics are described in section \ref{sec:dsdl_serialization_compo
     \caption{Serialized representation and extent\label{fig:dsdl_extent}}
 \end{figure}
 
-Where a non-sealed (delimited) type is defined \emph{without} an explicit extent value a default memory reserve is implied using the following function
-of the cumulative bit length set\footnote{Section \ref{sec:dsdl_composite_alignment_cumulative_bls}.}
-of its fields $B$:
-
-$$
-X_\text{default}\left(B\right) =
-\left\lceil{}\left\lfloor{}\frac{3}{2} \max{}\left(B\right)\right\rfloor{}/8\right\rceil{}8
-$$
-
 \begin{remark}
     Because of UAVCAN's commitment to determinism, memory buffer allocation can become an issue.
     When using a flat composite type (where each field is of a primitive type) with the implicit truncation rule,
@@ -421,47 +412,14 @@ $$
 
     Conventional protocols manage this simply by delaying the memory requirement identification until runtime,
     which is unacceptable to UAVCAN.
-    The solution for UAVCAN is to require implementations to reserve more memory than required
-    by the data type definition unless it is \verb|@sealed|
+    The solution for UAVCAN is to allow the data type author to require implementations to reserve more memory
+    than required by the data type definition unless it is \verb|@sealed|
     (or unless the implementation does use dynamic memory allocation).
-    The multiplier chosen to define the \emph{default} amount of reserve memory
-    (i.e., the amount if a specific extent value is not provided) was chosen arbitrarily
-    and is considered a common-sense default that is not optimized for any specific property of a system.
-    This approach allows for limited extensibility while enabling deterministic memory requirements.
 \end{remark}
 
-\begin{remark}
-    The extent of the following structure is 96 bits (12 bytes):
-    \begin{minted}{python}
-        uint16 foo
-        uint8[<=5] bar
-        @assert _offset_ == {24, 32, 40, 48, 56, 64}
-    \end{minted}
-    How it was computed: \verb|foo| is fixed-size at 16 bits,
-    the implicit array length prefix of \verb|bar| is 8 bits,
-    the maximum array body length is $8 \times 5$ bits:
-    $(16 + 8 + 8 \times 5) \times \frac{3}{2} = 96$ bits.
-
-    The extent of the following union is 88 bits (11 bytes):
-    \begin{minted}{python}
-        @union
-        uint16 foo
-        uint8[<=5] bar
-        @assert _offset_ == {16, 24, 32, 40, 48, 56}
-    \end{minted}
-\end{remark}
-
-The extent can be set explicitly\footnote{
-    Observe that when composites are nested,
-    the default extent of an outer composite will be increasing as an exponential
-    function of the number of levels of nesting (because each level introduces the fixed multiplier).
-    Therefore, it is advised to specify the extent manually to manage the memory requirement.
-}
-using the directive described in section \ref{sec:dsdl_directive_extent},
-unless the definition is sealed.
-
-By default, a definition is not sealed unless explicitly indicated otherwise using the directive described in
-section \ref{sec:dsdl_directive_sealed}.
+The extent shall be set explicitly using the directive described in section \ref{sec:dsdl_directive_extent},
+unless the definition is declared sealed using the directive described in section \ref{sec:dsdl_directive_sealed}.
+The directives are mutually exclusive.
 
 It is allowed for a sealed composite type to nest non-sealed (delimited) composite types, and vice versa.
 
@@ -511,11 +469,13 @@ as defined in section \ref{sec:dsdl_serialization_composite_non_sealed}.
         # A.1.0
         B.1.0 x
         float32 assume_aligned  # B.1.0 contains a single uint64, assume this field is 32-bit aligned?
+        @sealed
     \end{minted}
 
     \begin{minted}{python}
         # B.1.0
         uint64 x
+        @extent 8 * 8
     \end{minted}
 
     Imagine then that \verb|B.1.0| is replaced with the following:
@@ -524,6 +484,7 @@ as defined in section \ref{sec:dsdl_serialization_composite_non_sealed}.
         # B.1.1
         uint64 x
         bool[<=64] y
+        @extent 8 * 8
     \end{minted}
 
     Once this modification is introduced, the fragile assumption about the alignment of
@@ -631,6 +592,7 @@ one type is a subtype of another, and for any member its supertypes are located 
     \begin{minted}{python}
         float64 a       # Index 0
         int16[<=9] b    # Index 1
+        @extent 32 * 8
     \end{minted}
 
     The second type is a structural subtype of the first type:
@@ -639,6 +601,7 @@ one type is a subtype of another, and for any member its supertypes are located 
         float64 a       # Index 0
         int16[<=9] b    # Index 1
         uint8 foo       # Index 2
+        @extent 32 * 8
     \end{minted}
 
     Subtyping example for union types. First type:
@@ -648,6 +611,7 @@ one type is a subtype of another, and for any member its supertypes are located 
         uavcan.primitive.Empty.1.0 foo
         float16 bar
         uint8 zoo
+        @extent 128 * 8
     \end{minted}
 
     The second type is a structural subtype of the first type:
@@ -658,11 +622,12 @@ one type is a subtype of another, and for any member its supertypes are located 
         float16 bar                       # Same
         uint8 zoo                         # Same
         int64[<=64] baz                   # New field
+        @extent 128 * 8
     \end{minted}
 
-    A message type that defines zero fields is a structural supertype of any other message type, regardless of either
-    or both being a union.
-    A message type may have an arbitrary number of supertypes as long as the field equality constraint is satisfied.
+    A structure type that defines zero fields is a structural supertype of any other structure type,
+    regardless of either or both being a union, provided that its extent is sufficient.
+    A structure type may have an arbitrary number of supertypes as long as the field equality constraint is satisfied.
 
     Header subtyping example. The first type is named \verb|A.1.0|:
 

--- a/specification/introduction/introduction.tex
+++ b/specification/introduction/introduction.tex
@@ -63,6 +63,7 @@ If a different base is used, it is specified after the number in the subscript\f
 
 DSDL definition examples provided in the document are illustrative and may be incomplete or invalid.
 This is to ensure that the examples are not cluttered by irrelevant details.
+For example, \verb|@extent| or \verb|@sealed| directives may be omitted if not relevant.
 
 \section{Design principles}
 

--- a/specification/introduction/introduction.tex
+++ b/specification/introduction/introduction.tex
@@ -208,6 +208,9 @@ The UAVCAN specification contains references to the following sources:
 
 \begin{itemize}
     \item The maximum data type name length has been increased from 50 to 255 characters.
+
+    \item The default extent function has been removed (section \ref{sec:dsdl_composite_extent_and_sealing}).
+    The extent now has to be specified explicitly always unless the data type is sealed.
 \end{itemize}
 
 \subsection{v1.0-beta -- Sep 2020}
@@ -216,17 +219,17 @@ Compared to v1.0-alpha, the differences are as follows (the motivation is provid
 
 \begin{itemize}
     \item The physical layer specification has been removed.
-          It is now up to the domain-specific UAVCAN-based standards to define the physical layer.
+    It is now up to the domain-specific UAVCAN-based standards to define the physical layer.
 
     \item The subject-ID range reduced from $[0, 32767]$ down to $[0, 8191]$.
-          This change may be reverted in a future edition of the standard, if found practical.
+    This change may be reverted in a future edition of the standard, if found practical.
 
     \item Added support for delimited serialization; introduced related concepts of \emph{extent} and \emph{sealing}
-          (section \ref{sec:dsdl_composite_extent_and_sealing}).
-          This change enables one to easily evolve networked services in a backward-compatible way.
+    (section \ref{sec:dsdl_composite_extent_and_sealing}).
+    This change enables one to easily evolve networked services in a backward-compatible way.
 
     \item Enabled the automatic runtime adjustment of the transfer-ID timeout on a per-subject basis
-          as a function of the transfer reception rate (section \ref{sec:transport_transfer_reception}).
+    as a function of the transfer reception rate (section \ref{sec:transport_transfer_reception}).
 \end{itemize}
 
 \subsection{v1.0-alpha -- Jan 2020}

--- a/specification/introduction/introduction.tex
+++ b/specification/introduction/introduction.tex
@@ -61,6 +61,9 @@ If a different base is used, it is specified after the number in the subscript\f
     E.g., $\text{BADC0FFEE}_{16} = 50159747054$, $10101_2 = 21$.
 }.
 
+DSDL definition examples provided in the document are illustrative and may be incomplete or invalid.
+This is to ensure that the examples are not cluttered by irrelevant details.
+
 \section{Design principles}
 
 \begin{description}


### PR DESCRIPTION
Context: https://forum.uavcan.org/t/default-extent-considered-harmful/972

It is now necessary to always specify either `@sealed` or `@extent <...>`.